### PR TITLE
SDCORE-44 Configuration APIs in SMF, reset default user plane path on config change

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -288,6 +288,9 @@ func ProcessConfigUpdate() bool {
 		factory.UpdatedSmfConfig.DelLinks = nil
 	}
 
+	//Any time config changes(Slices/UPFs/Links) then reset Default path(Key= nssai+Dnn)
+	GetUserPlaneInformation().ResetDefaultUserPlanePath()
+
 	//Send NRF Re-register if Slice info got updated
 	if sendNrfRegistration {
 		SetupNFProfile(&factory.SmfConfig)

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -101,6 +101,11 @@ func (upi *UserPlaneInformation) GetUPFIDByIP(ip string) string {
 	return upi.UPFsIPtoID[ip]
 }
 
+func (upi *UserPlaneInformation) ResetDefaultUserPlanePath() {
+	logger.UPNodeLog.Infof("resetting the default user plane paths [%v]", upi.DefaultUserPlanePath)
+	upi.DefaultUserPlanePath = make(map[string][]*UPNode)
+}
+
 func (upi *UserPlaneInformation) GetDefaultUserPlanePathByDNN(selection *UPFSelectionParams) (path UPPath) {
 	path, pathExist := upi.DefaultUserPlanePath[selection.String()]
 	logger.CtxLog.Traceln("In GetDefaultUserPlanePathByDNN")
@@ -432,7 +437,7 @@ func (upi *UserPlaneInformation) DeleteUPNodeLinks(link *factory.UPLink) error {
 
 	logger.UPNodeLog.Infof("deleting UP Node link[%v] ", link)
 	logger.UPNodeLog.Debugf("current UP Nodes [%+v]", upi.UPNodes)
-  
+
 	nodeA := upi.UPNodes[link.A]
 	nodeB := upi.UPNodes[link.B]
 


### PR DESCRIPTION
SDCORE-44 Configuration APIs in SMF, reset default user plane path on Slice/userplane config change