### PR TITLE
Allow disabling Kafka integration

### DIFF
--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -21,7 +21,6 @@ configuration:
     brokerUri: "sd-core-kafka-headless"
     brokerPort: 9092
     topicName: "sdcore-data-source-smf"
-    disableKafka: false
   staticIpInfo:
     - dnn: internet_1
       imsiIpInfo:

--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -21,6 +21,7 @@ configuration:
     brokerUri: "sd-core-kafka-headless"
     brokerPort: 9092
     topicName: "sdcore-data-source-smf"
+    disableKafka: false
   staticIpInfo:
     - dnn: internet_1
       imsiIpInfo:

--- a/factory/config.go
+++ b/factory/config.go
@@ -65,9 +65,10 @@ type Mongodb struct {
 }
 
 type KafkaInfo struct {
-	BrokerUri  string `yaml:"brokerUri,omitempty"`
-	BrokerPort int    `yaml:"brokerPort,omitempty"`
-	Topic      string `yaml:"topicName,omitempty"`
+	BrokerUri    string `yaml:"brokerUri,omitempty"`
+	BrokerPort   int    `yaml:"brokerPort,omitempty"`
+	Topic        string `yaml:"topicName,omitempty"`
+	DisableKafka bool   `yaml:"disableKafka,omitempty"`
 }
 
 type Configuration struct {

--- a/factory/config.go
+++ b/factory/config.go
@@ -65,10 +65,10 @@ type Mongodb struct {
 }
 
 type KafkaInfo struct {
-	BrokerUri    string `yaml:"brokerUri,omitempty"`
-	BrokerPort   int    `yaml:"brokerPort,omitempty"`
-	Topic        string `yaml:"topicName,omitempty"`
-	DisableKafka bool   `yaml:"disableKafka,omitempty"`
+	BrokerUri   string `yaml:"brokerUri,omitempty"`
+	BrokerPort  int    `yaml:"brokerPort,omitempty"`
+	Topic       string `yaml:"topicName,omitempty"`
+	EnableKafka *bool  `yaml:"enableKafka,omitempty"`
 }
 
 type Configuration struct {

--- a/factory/config_test.go
+++ b/factory/config_test.go
@@ -144,3 +144,10 @@ func TestCompareGenericSlices(t *testing.T) {
 		fmt.Println("Generic, The Links match")
 	}
 }
+
+func TestKafkaEnabledByDefault(t *testing.T) {
+	kafkaConfig := KafkaInfo{}
+	if kafkaConfig.DisableKafka != false {
+		t.Errorf("Expected Kafka to be enabled by default, was disabled")
+	}
+}

--- a/factory/config_test.go
+++ b/factory/config_test.go
@@ -146,8 +146,11 @@ func TestCompareGenericSlices(t *testing.T) {
 }
 
 func TestKafkaEnabledByDefault(t *testing.T) {
-	kafkaConfig := KafkaInfo{}
-	if kafkaConfig.DisableKafka != false {
+	err := InitConfigFactory("../config/smfcfg.yaml")
+	if err != nil {
+		t.Errorf("Could not load default configuration file: %v", err)
+	}
+	if *SmfConfig.Configuration.KafkaInfo.EnableKafka != true {
 		t.Errorf("Expected Kafka to be enabled by default, was disabled")
 	}
 }

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -39,6 +39,11 @@ func InitConfigFactory(f string) error {
 			return yamlErr
 		}
 
+		if SmfConfig.Configuration.KafkaInfo.EnableKafka == nil {
+			enableKafka := true
+			SmfConfig.Configuration.KafkaInfo.EnableKafka = &enableKafka
+		}
+
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			gClient := client.ConnectToConfigServer("webui:9876")

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -27,7 +27,7 @@ var StatWriter Writer
 
 func InitialiseKafkaStream(config *factory.Configuration) error {
 
-	if config.KafkaInfo.DisableKafka == true {
+	if *config.KafkaInfo.EnableKafka == false {
 		return nil
 	}
 
@@ -65,7 +65,7 @@ func GetWriter() Writer {
 }
 
 func (writer Writer) SendMessage(message []byte) error {
-	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+	if *factory.SmfConfig.Configuration.KafkaInfo.EnableKafka == false {
 		return nil
 	}
 	msg := kafka.Message{Value: message}
@@ -78,7 +78,7 @@ func (writer Writer) SendMessage(message []byte) error {
 
 func (writer Writer) PublishPduSessEvent(ctxt mi.CoreSubscriber, op mi.SubscriberOp) error {
 
-	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+	if *factory.SmfConfig.Configuration.KafkaInfo.EnableKafka == false {
 		return nil
 	}
 	smKafkaEvt := mi.MetricEvent{EventType: mi.CSubscriberEvt,
@@ -102,7 +102,7 @@ func SetNfInstanceId(s string) {
 
 func PublishMsgEvent(msgType mi.SmfMsgType) error {
 
-	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+	if *factory.SmfConfig.Configuration.KafkaInfo.EnableKafka == false {
 		return nil
 	}
 	smKafkaMsgEvt := mi.MetricEvent{EventType: mi.CMsgTypeEvt, MsgType: mi.CoreMsgType{MsgType: msgType.String(), SourceNfId: nfInstanceId}}
@@ -118,7 +118,7 @@ func PublishMsgEvent(msgType mi.SmfMsgType) error {
 
 func (writer Writer) PublishNfStatusEvent(msgEvent mi.MetricEvent) error {
 
-	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+	if *factory.SmfConfig.Configuration.KafkaInfo.EnableKafka == false {
 		return nil
 	}
 	if msg, err := json.Marshal(msgEvent); err != nil {

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Writer struct {
-	kafkaWriter kafka.Writer
+	kafkaWriter *kafka.Writer
 }
 
 var StatWriter Writer
@@ -54,7 +54,7 @@ func InitialiseKafkaStream(config *factory.Configuration) error {
 	}
 
 	StatWriter = Writer{
-		kafkaWriter: producer,
+		kafkaWriter: &producer,
 	}
 	return nil
 }

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -27,6 +27,10 @@ var StatWriter Writer
 
 func InitialiseKafkaStream(config *factory.Configuration) error {
 
+	if config.KafkaInfo.DisableKafka == true {
+		return nil
+	}
+
 	brokerUrl := "sd-core-kafka-headless:9092"
 	topicName := "sdcore-data-source-smf"
 
@@ -61,6 +65,9 @@ func GetWriter() Writer {
 }
 
 func (writer Writer) SendMessage(message []byte) error {
+	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+		return nil
+	}
 	msg := kafka.Message{Value: message}
 	if err := writer.kafkaWriter.WriteMessages(context.Background(), msg); err != nil {
 		logger.KafkaLog.Errorf("kafka send message write error: [%v] ", err.Error())
@@ -71,6 +78,9 @@ func (writer Writer) SendMessage(message []byte) error {
 
 func (writer Writer) PublishPduSessEvent(ctxt mi.CoreSubscriber, op mi.SubscriberOp) error {
 
+	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+		return nil
+	}
 	smKafkaEvt := mi.MetricEvent{EventType: mi.CSubscriberEvt,
 		SubscriberData: mi.CoreSubscriberData{Subscriber: ctxt, Operation: op}}
 	if msg, err := json.Marshal(smKafkaEvt); err != nil {
@@ -92,6 +102,9 @@ func SetNfInstanceId(s string) {
 
 func PublishMsgEvent(msgType mi.SmfMsgType) error {
 
+	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+		return nil
+	}
 	smKafkaMsgEvt := mi.MetricEvent{EventType: mi.CMsgTypeEvt, MsgType: mi.CoreMsgType{MsgType: msgType.String(), SourceNfId: nfInstanceId}}
 	if msg, err := json.Marshal(smKafkaMsgEvt); err != nil {
 		logger.KafkaLog.Errorf("publishing msg event marshal error [%v] ", err.Error())
@@ -105,6 +118,9 @@ func PublishMsgEvent(msgType mi.SmfMsgType) error {
 
 func (writer Writer) PublishNfStatusEvent(msgEvent mi.MetricEvent) error {
 
+	if factory.SmfConfig.Configuration.KafkaInfo.DisableKafka == true {
+		return nil
+	}
 	if msg, err := json.Marshal(msgEvent); err != nil {
 		logger.KafkaLog.Errorf("publishing nf status marshal error [%v] ", err.Error())
 		return err

--- a/metrics/kafka_test.go
+++ b/metrics/kafka_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/omec-project/smf/factory"
 )
 
+var my_false bool = false
+
 func TestInitializeKafkaStreamWithKafkaDisabled(t *testing.T) {
 	config := factory.Configuration{
 		KafkaInfo: factory.KafkaInfo{
-			DisableKafka: true,
+			EnableKafka: &my_false,
 		},
 	}
 
@@ -27,7 +29,7 @@ func TestInitializeKafkaStreamWithKafkaDisabled(t *testing.T) {
 func TestSendMessageWithKafkaDisabled(t *testing.T) {
 	configuration := factory.Configuration{
 		KafkaInfo: factory.KafkaInfo{
-			DisableKafka: true,
+			EnableKafka: &my_false,
 		},
 	}
 	config := factory.Config{
@@ -50,7 +52,7 @@ func TestSendMessageWithKafkaDisabled(t *testing.T) {
 func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
 	configuration := factory.Configuration{
 		KafkaInfo: factory.KafkaInfo{
-			DisableKafka: true,
+			EnableKafka: &my_false,
 		},
 	}
 	config := factory.Config{
@@ -73,7 +75,7 @@ func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
 func TestPublishMsgEventWithKafkaDisabled(t *testing.T) {
 	configuration := factory.Configuration{
 		KafkaInfo: factory.KafkaInfo{
-			DisableKafka: true,
+			EnableKafka: &my_false,
 		},
 	}
 	config := factory.Config{
@@ -94,7 +96,7 @@ func TestPublishMsgEventWithKafkaDisabled(t *testing.T) {
 func TestPublishNfStatusWithKafkaDisabled(t *testing.T) {
 	configuration := factory.Configuration{
 		KafkaInfo: factory.KafkaInfo{
-			DisableKafka: true,
+			EnableKafka: &my_false,
 		},
 	}
 	config := factory.Config{

--- a/metrics/kafka_test.go
+++ b/metrics/kafka_test.go
@@ -1,0 +1,115 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/omec-project/metricfunc/pkg/metricinfo"
+	"github.com/omec-project/smf/factory"
+)
+
+func TestInitializeKafkaStreamWithKafkaDisabled(t *testing.T) {
+	config := factory.Configuration{
+		KafkaInfo: factory.KafkaInfo{
+			DisableKafka: true,
+		},
+	}
+
+	result := InitialiseKafkaStream(&config)
+
+	if result != nil {
+		t.Errorf("Expected return value to be nil, got %v", result)
+	}
+	if StatWriter.kafkaWriter != nil {
+		t.Errorf("Expected kafkaWrite to be nil, got %v", StatWriter.kafkaWriter)
+	}
+}
+
+func TestSendMessageWithKafkaDisabled(t *testing.T) {
+	configuration := factory.Configuration{
+		KafkaInfo: factory.KafkaInfo{
+			DisableKafka: true,
+		},
+	}
+	config := factory.Config{
+		Configuration: &configuration,
+	}
+	factory.SmfConfig = config
+
+	InitialiseKafkaStream(&configuration)
+
+	writer := GetWriter()
+
+	// If the kafkaWriter is called, this will panic and fail the test
+	result := writer.SendMessage([]byte{0xFF})
+
+	if result != nil {
+		t.Errorf("Expected return value to be nil, got %v", result)
+	}
+}
+
+func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
+	configuration := factory.Configuration{
+		KafkaInfo: factory.KafkaInfo{
+			DisableKafka: true,
+		},
+	}
+	config := factory.Config{
+		Configuration: &configuration,
+	}
+	factory.SmfConfig = config
+
+	InitialiseKafkaStream(&configuration)
+
+	writer := GetWriter()
+
+	// If the kafkaWriter is called, this will panic and fail the test
+	result := writer.PublishPduSessEvent(metricinfo.CoreSubscriber{}, 0)
+
+	if result != nil {
+		t.Errorf("Expected return value to be nil, got %v", result)
+	}
+}
+
+func TestPublishMsgEventWithKafkaDisabled(t *testing.T) {
+	configuration := factory.Configuration{
+		KafkaInfo: factory.KafkaInfo{
+			DisableKafka: true,
+		},
+	}
+	config := factory.Config{
+		Configuration: &configuration,
+	}
+	factory.SmfConfig = config
+
+	InitialiseKafkaStream(&configuration)
+
+	// If the kafkaWriter is called, this will panic and fail the test
+	result := PublishMsgEvent(0)
+
+	if result != nil {
+		t.Errorf("Expected return value to be nil, got %v", result)
+	}
+}
+
+func TestPublishNfStatusWithKafkaDisabled(t *testing.T) {
+	configuration := factory.Configuration{
+		KafkaInfo: factory.KafkaInfo{
+			DisableKafka: true,
+		},
+	}
+	config := factory.Config{
+		Configuration: &configuration,
+	}
+	factory.SmfConfig = config
+
+	InitialiseKafkaStream(&configuration)
+
+	writer := GetWriter()
+
+	// If the kafkaWriter is called, this will panic and fail the test
+	result := writer.PublishNfStatusEvent(metricinfo.MetricEvent{})
+
+	if result != nil {
+		t.Errorf("Expected return value to be nil, got %v", result)
+	}
+}

--- a/metrics/kafka_test.go
+++ b/metrics/kafka_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Open Networking Foundation <info@opennetworking.org>
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (


### PR DESCRIPTION
This PR allows the SMF to be deployed without Kafka, by setting the new configuration option `disableKafka` to `true`. This keeps the current behavior of enabling Kafka as the default.

Also fixes an issue where the `kafkaWriter` was passed by value, instead of using a pointer.