### PR TITLE
fix: Do not log mongo credentials

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -380,7 +380,7 @@ func (smfCtxt *SMFContext) InitDrsm() error {
 		dbName = factory.SmfConfig.Configuration.SmfDbName
 	}
 
-	logger.CfgLog.Infof("initialising drsm name [%v] url [%v] ", dbName, dbUrl)
+	logger.CfgLog.Infof("initialising drsm name [%v]", dbName)
 
 	opt := &drsm.Options{ResIdSize: 24, Mode: drsm.ResourceClient}
 	db := drsm.DbInfo{Url: dbUrl, Name: dbName}


### PR DESCRIPTION
Logging the mongo URI also logs the credentials used to connect, which is a security issue. This PR removes the URI from the logs to prevent secrets leaking.