### PR TITLE
chore: Move idgenerator import path to util project

### DIFF
--- a/context/db.go
+++ b/context/db.go
@@ -24,7 +24,7 @@ import (
 
 	"strconv"
 
-	"github.com/omec-project/idgenerator"
+	"github.com/omec-project/util/idgenerator"
 
 	"os"
 )

--- a/context/db_uptunnel.go
+++ b/context/db_uptunnel.go
@@ -12,8 +12,8 @@ import (
 	"github.com/omec-project/MongoDBLibrary"
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/omec-project/idgenerator"
 	"github.com/omec-project/smf/logger"
+	"github.com/omec-project/util/idgenerator"
 
 	"github.com/omec-project/pfcp/pfcpType"
 )

--- a/context/ue_datapath.go
+++ b/context/ue_datapath.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/omec-project/idgenerator"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
+	"github.com/omec-project/util/idgenerator"
 )
 
 type UEPreConfigPaths struct {

--- a/context/upf.go
+++ b/context/upf.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/omec-project/idgenerator"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/pfcp/pfcpType"
 	"github.com/omec-project/pfcp/pfcpUdp"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
+	"github.com/omec-project/util/idgenerator"
 
 	// "github.com/omec-project/MongoDBLibrary"
 	"os"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/omec-project/flowdesc v1.1.0
 	github.com/omec-project/http2_util v1.1.0
 	github.com/omec-project/http_wrapper v1.1.0
-	github.com/omec-project/idgenerator v1.1.0
 	github.com/omec-project/logger_util v1.1.0
 	github.com/omec-project/nas v1.1.4
 	github.com/omec-project/ngap v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,6 @@ github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9
 github.com/omec-project/http2_util v1.1.0/go.mod h1:QwoZRaUyhEp/kTEqXvf0gCYtfQrNHBdkVw939vsMjZY=
 github.com/omec-project/http_wrapper v1.1.0 h1:2hD8RUaR/VVg3tUUfuxsuo1/JNpZLiAE8IvATGqDME4=
 github.com/omec-project/http_wrapper v1.1.0/go.mod h1:mc045fjVVJ0/q0g4QG4nuSC0N1BIqGR/ZoK76XgifVU=
-github.com/omec-project/idgenerator v1.1.0 h1:XDHZYO13VqZCkRhMA4xNl19MqCL3AFaY2MNwoF8uzVs=
-github.com/omec-project/idgenerator v1.1.0/go.mod h1:qFK0oP9WNCBjro7ZXPzmbSzCosWmxp4KRVORPl6ztRo=
 github.com/omec-project/logger_conf v1.0.100-dev/go.mod h1:Upj0MgzSpB/Ifw+3WsBaYbqWuF4SyyUeKqW7/HhL8Aw=
 github.com/omec-project/logger_conf v1.1.0 h1:C0/HbsSOWV8D3/lm7Iqe1nUL9ltVtVO4MDC9ZxIo/xc=
 github.com/omec-project/logger_conf v1.1.0/go.mod h1:2+SOX9OFbPZ+UNv8k+tvPnaWHo4CuX5G/x12dz5sWUE=


### PR DESCRIPTION
Changes the import path of `idgenerator` to the `util` project. Tested with a successful `gnbsim` simulation.