### PR TITLE
feat: parametrize paths for TLS certificate and private key

### DIFF
--- a/service/init.go
+++ b/service/init.go
@@ -381,10 +381,12 @@ func (smf *SMF) Start() {
 	}
 
 	serverScheme := factory.SmfConfig.Configuration.Sbi.Scheme
+	smfPemPath := path_util.Free5gcPath(factory.SmfConfig.Configuration.Sbi.TLS.PEM)
+	smfKeyPath := path_util.Free5gcPath(factory.SmfConfig.Configuration.Sbi.TLS.Key)
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(util.SmfPemPath, util.SmfKeyPath)
+		err = server.ListenAndServeTLS(smfPemPath, smfKeyPath)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR enables to set custom paths for TLS certificate and private key.
In particular, the configuration for the paths is already present, but it was ignored when starting the HTTP server.