### PR TITLE
fix: use absolute paths for TLS certificate and private key

### DIFF
--- a/config/smfcfg.yaml
+++ b/config/smfcfg.yaml
@@ -41,8 +41,8 @@ configuration:
     bindingIPv4: smf  # IP used to bind the service
     port: 29502 # Port used to bind the service
     tls: # the local path of TLS key
-      key: free5gc/support/TLS/smf.key # SMF TLS Certificate
-      pem: free5gc/support/TLS/smf.pem # SMF TLS Private key
+      key: /support/TLS/smf.key # SMF TLS Certificate
+      pem: /support/TLS/smf.pem # SMF TLS Private key
   serviceNameList: # the SBI services provided by this SMF, refer to TS 29.502
     - nsmf-pdusession # Nsmf_PDUSession service
     - nsmf-event-exposure # Nsmf_EventExposure service

--- a/context/context.go
+++ b/context/context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
 	"github.com/omec-project/smf/metrics"
+	"github.com/omec-project/smf/util"
 	"github.com/omec-project/util/drsm"
 )
 
@@ -148,6 +149,9 @@ func InitSmfContext(config *factory.Config) *SMFContext {
 		smfContext.URIScheme = models.UriScheme(sbi.Scheme)
 		smfContext.RegisterIPv4 = factory.SMF_DEFAULT_IPV4 // default localhost
 		smfContext.SBIPort = factory.SMF_DEFAULT_PORT_INT  // default port
+		smfContext.Key = util.SmfKeyPath                   // default key path
+		smfContext.PEM = util.SmfPemPath                   // default PEM path
+
 		if sbi.RegisterIPv4 != "" {
 			// smfContext.RegisterIPv4 = sbi.RegisterIPv4
 			sbi.RegisterIPv4 = localIp
@@ -160,8 +164,12 @@ func InitSmfContext(config *factory.Config) *SMFContext {
 		}
 
 		if tls := sbi.TLS; tls != nil {
-			smfContext.Key = tls.Key
-			smfContext.PEM = tls.PEM
+			if tls.Key != "" {
+				smfContext.Key = tls.Key
+			}
+			if tls.PEM != "" {
+				smfContext.PEM = tls.PEM
+			}
 		}
 
 		smfContext.BindingIPv4 = os.Getenv(sbi.BindingIPv4)

--- a/service/init.go
+++ b/service/init.go
@@ -381,8 +381,8 @@ func (smf *SMF) Start() {
 	}
 
 	serverScheme := factory.SmfConfig.Configuration.Sbi.Scheme
-	smfPemPath := path_util.Free5gcPath(factory.SmfConfig.Configuration.Sbi.TLS.PEM)
-	smfKeyPath := path_util.Free5gcPath(factory.SmfConfig.Configuration.Sbi.TLS.Key)
+	smfPemPath := factory.SmfConfig.Configuration.Sbi.TLS.PEM
+	smfKeyPath := factory.SmfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {

--- a/service/init.go
+++ b/service/init.go
@@ -381,12 +381,10 @@ func (smf *SMF) Start() {
 	}
 
 	serverScheme := factory.SmfConfig.Configuration.Sbi.Scheme
-	smfPemPath := factory.SmfConfig.Configuration.Sbi.TLS.PEM
-	smfKeyPath := factory.SmfConfig.Configuration.Sbi.TLS.Key
 	if serverScheme == "http" {
 		err = server.ListenAndServe()
 	} else if serverScheme == "https" {
-		err = server.ListenAndServeTLS(smfPemPath, smfKeyPath)
+		err = server.ListenAndServeTLS(context.SMF_Self().PEM, context.SMF_Self().Key)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This PR replaces the usage of `Free5gcPath` in favor of the absolute path in configuration for TLS certificate and private key. This is necessary to allow any config-provided path to be used for certificate in the HTTPS server.