### PR TITLE
chore: activate errcheck linter and check corresponding errors

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -61,7 +61,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6.0.1
         with:
           version: latest
-          args: -v --config ./.golangci.yml
+          args: -v --timeout=5m  --config ./.golangci.yml
 
   hadolint:
     name: hadolint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -238,7 +238,7 @@ linters:
   enable:
     - gofmt
     - govet
-    # - errcheck
+    - errcheck
     # - staticcheck
     - unused
     - gosimple

--- a/context/config.go
+++ b/context/config.go
@@ -27,7 +27,10 @@ func (c *SMFContext) insertSmfNssaiInfo(snssaiInfoConfig *factory.SnssaiInfoItem
 	// Check if prev slice with same sst+sd exist
 	if slice := c.getSmfNssaiInfo(snssaiInfoConfig.SNssai.Sst, snssaiInfoConfig.SNssai.Sd); slice != nil {
 		logger.InitLog.Errorf("network slice [%v] already exist, deleting", factory.PrettyPrintNetworkSlices([]factory.SnssaiInfoItem{*snssaiInfoConfig}))
-		c.deleteSmfNssaiInfo(snssaiInfoConfig)
+		err := c.deleteSmfNssaiInfo(snssaiInfoConfig)
+		if err != nil {
+			logger.InitLog.Errorf("network slice delete error %v", err)
+		}
 	}
 
 	snssaiInfo := SnssaiSmfInfo{}

--- a/context/context.go
+++ b/context/context.go
@@ -219,7 +219,10 @@ func InitSmfContext(config *factory.Config) *SMFContext {
 
 	// Static config
 	for _, snssaiInfoConfig := range configuration.SNssaiInfo {
-		smfContext.insertSmfNssaiInfo(&snssaiInfoConfig)
+		err := smfContext.insertSmfNssaiInfo(&snssaiInfoConfig)
+		if err != nil {
+			logger.CtxLog.Warnln(err)
+		}
 	}
 
 	// Set client and set url
@@ -299,7 +302,10 @@ func ProcessConfigUpdate() bool {
 	// Lets parse through network slice configs first
 	if updatedCfg.DelSNssaiInfo != nil {
 		for _, slice := range *updatedCfg.DelSNssaiInfo {
-			SMF_Self().deleteSmfNssaiInfo(&slice)
+			err := SMF_Self().deleteSmfNssaiInfo(&slice)
+			if err != nil {
+				logger.CtxLog.Errorf("delete network slice [%v] failed: %v", slice, err)
+			}
 		}
 		factory.UpdatedSmfConfig.DelSNssaiInfo = nil
 		sendNrfRegistration = true
@@ -307,7 +313,10 @@ func ProcessConfigUpdate() bool {
 
 	if updatedCfg.AddSNssaiInfo != nil {
 		for _, slice := range *updatedCfg.AddSNssaiInfo {
-			SMF_Self().insertSmfNssaiInfo(&slice)
+			err := SMF_Self().insertSmfNssaiInfo(&slice)
+			if err != nil {
+				logger.CtxLog.Errorf("insert network slice [%v] failed: %v", slice, err)
+			}
 		}
 		factory.UpdatedSmfConfig.AddSNssaiInfo = nil
 		sendNrfRegistration = true
@@ -315,7 +324,10 @@ func ProcessConfigUpdate() bool {
 
 	if updatedCfg.ModSNssaiInfo != nil {
 		for _, slice := range *updatedCfg.ModSNssaiInfo {
-			SMF_Self().updateSmfNssaiInfo(&slice)
+			err := SMF_Self().updateSmfNssaiInfo(&slice)
+			if err != nil {
+				logger.CtxLog.Errorf("update network slice [%v] failed: %v", slice, err)
+			}
 		}
 		factory.UpdatedSmfConfig.ModSNssaiInfo = nil
 		sendNrfRegistration = true
@@ -324,7 +336,10 @@ func ProcessConfigUpdate() bool {
 	// UP Node Links should be deleted before underlying UPFs are deleted
 	if updatedCfg.DelLinks != nil {
 		for _, link := range *updatedCfg.DelLinks {
-			GetUserPlaneInformation().DeleteUPNodeLinks(&link)
+			err := GetUserPlaneInformation().DeleteUPNodeLinks(&link)
+			if err != nil {
+				logger.CtxLog.Errorf("delete UP Node Links failed: %v", err)
+			}
 		}
 		factory.UpdatedSmfConfig.DelLinks = nil
 	}
@@ -332,14 +347,20 @@ func ProcessConfigUpdate() bool {
 	// Iterate through UserPlane Info
 	if updatedCfg.DelUPNodes != nil {
 		for name, upf := range *updatedCfg.DelUPNodes {
-			GetUserPlaneInformation().DeleteSmfUserPlaneNode(name, &upf)
+			err := GetUserPlaneInformation().DeleteSmfUserPlaneNode(name, &upf)
+			if err != nil {
+				logger.CtxLog.Errorf("delete UP Node [%s] failed: %v", name, err)
+			}
 		}
 		factory.UpdatedSmfConfig.DelUPNodes = nil
 	}
 
 	if updatedCfg.AddUPNodes != nil {
 		for name, upf := range *updatedCfg.AddUPNodes {
-			GetUserPlaneInformation().InsertSmfUserPlaneNode(name, &upf)
+			err := GetUserPlaneInformation().InsertSmfUserPlaneNode(name, &upf)
+			if err != nil {
+				logger.CtxLog.Errorf("insert UP Node [%s] failed: %v", name, err)
+			}
 		}
 		factory.UpdatedSmfConfig.AddUPNodes = nil
 		AllocateUPFID()
@@ -348,7 +369,10 @@ func ProcessConfigUpdate() bool {
 
 	if updatedCfg.ModUPNodes != nil {
 		for name, upf := range *updatedCfg.ModUPNodes {
-			GetUserPlaneInformation().UpdateSmfUserPlaneNode(name, &upf)
+			err := GetUserPlaneInformation().UpdateSmfUserPlaneNode(name, &upf)
+			if err != nil {
+				logger.CtxLog.Errorf("update UP Node [%s] failed: %v", name, err)
+			}
 		}
 		factory.UpdatedSmfConfig.ModUPNodes = nil
 	}
@@ -357,7 +381,10 @@ func ProcessConfigUpdate() bool {
 	// UP Links should be added only after underlying UPFs have been added
 	if updatedCfg.AddLinks != nil {
 		for _, link := range *updatedCfg.AddLinks {
-			GetUserPlaneInformation().InsertUPNodeLinks(&link)
+			err := GetUserPlaneInformation().InsertUPNodeLinks(&link)
+			if err != nil {
+				logger.CtxLog.Errorf("insert UP Node Links failed: %v", err)
+			}
 		}
 		factory.UpdatedSmfConfig.AddLinks = nil
 	}

--- a/context/datapath.go
+++ b/context/datapath.go
@@ -255,14 +255,17 @@ func (node *DataPathNode) DeactivateUpLinkTunnel(smContext *SMContext) {
 	}
 
 	teid := node.DownLinkTunnel.TEID
-	smfContext.DrsmCtxts.TeidPool.ReleaseInt32ID(int32(teid))
+	err := smfContext.DrsmCtxts.TeidPool.ReleaseInt32ID(int32(teid))
+	if err != nil {
+		logger.CtxLog.Errorln("deactivated UpLinkTunnel", err)
+	}
 	node.DownLinkTunnel = &GTPTunnel{}
 }
 
 func (node *DataPathNode) DeactivateDownLinkTunnel(smContext *SMContext) {
 	for name, pdr := range node.DownLinkTunnel.PDR {
 		if pdr != nil {
-			logger.CtxLog.Infof("Deactivaed DownLinkTunnel PDR name[%v], id[%v]", name, pdr.PDRID)
+			logger.CtxLog.Infof("deactivated DownLinkTunnel PDR name[%v], id[%v]", name, pdr.PDRID)
 
 			// Remove PDR from PFCP Session
 			smContext.RemovePDRfromPFCPSession(node.UPF.NodeID, pdr)
@@ -270,20 +273,20 @@ func (node *DataPathNode) DeactivateDownLinkTunnel(smContext *SMContext) {
 			// Remove from UPF
 			err := node.UPF.RemovePDR(pdr)
 			if err != nil {
-				logger.CtxLog.Warnln("Deactivaed DownLinkTunnel", err)
+				logger.CtxLog.Warnln("deactivated DownLinkTunnel", err)
 			}
 
 			if far := pdr.FAR; far != nil {
 				err = node.UPF.RemoveFAR(far)
 				if err != nil {
-					logger.CtxLog.Warnln("Deactivaed DownLinkTunnel", err)
+					logger.CtxLog.Warnln("deactivated DownLinkTunnel", err)
 				}
 
 				bar := far.BAR
 				if bar != nil {
 					err = node.UPF.RemoveBAR(bar)
 					if err != nil {
-						logger.CtxLog.Warnln("Deactivaed DownLinkTunnel", err)
+						logger.CtxLog.Warnln("deactivated DownLinkTunnel", err)
 					}
 				}
 			}
@@ -292,7 +295,7 @@ func (node *DataPathNode) DeactivateDownLinkTunnel(smContext *SMContext) {
 					if qer != nil {
 						err = node.UPF.RemoveQER(qer)
 						if err != nil {
-							logger.CtxLog.Warnln("Deactivaed UpLinkTunnel", err)
+							logger.CtxLog.Warnln("deactivated UpLinkTunnel", err)
 						}
 					}
 				}
@@ -301,7 +304,10 @@ func (node *DataPathNode) DeactivateDownLinkTunnel(smContext *SMContext) {
 	}
 
 	teid := node.DownLinkTunnel.TEID
-	smfContext.DrsmCtxts.TeidPool.ReleaseInt32ID(int32(teid))
+	err := smfContext.DrsmCtxts.TeidPool.ReleaseInt32ID(int32(teid))
+	if err != nil {
+		logger.CtxLog.Errorln("deactivated DownLinkTunnel", err)
+	}
 	node.DownLinkTunnel = &GTPTunnel{}
 }
 

--- a/context/db.go
+++ b/context/db.go
@@ -158,8 +158,16 @@ func (smContext *SMContext) UnmarshalJSON(data []byte) error {
 		smContext.PFCPContext[key] = &PFCPSessionContext{}
 		smContext.PFCPContext[key].NodeID = pfcpCtxInDB.NodeID
 		smContext.PFCPContext[key].PDRs = pfcpCtxInDB.PDRs
-		smContext.PFCPContext[key].LocalSEID, _ = strconv.ParseUint(pfcpCtxInDB.LocalSEID, 16, 64)
-		smContext.PFCPContext[key].RemoteSEID, _ = strconv.ParseUint(pfcpCtxInDB.RemoteSEID, 16, 64)
+		localSeid, err := strconv.ParseUint(pfcpCtxInDB.LocalSEID, 16, 64)
+		if err != nil {
+			logger.DataRepoLog.Errorf("LocalSEID unmarshall error: %v", err)
+		}
+		smContext.PFCPContext[key].LocalSEID = localSeid
+		remoteSeid, err := strconv.ParseUint(pfcpCtxInDB.RemoteSEID, 16, 64)
+		if err != nil {
+			logger.DataRepoLog.Errorf("RemoteSEID unmarshall error: %v", err)
+		}
+		smContext.PFCPContext[key].RemoteSEID = remoteSeid
 	}
 
 	var dataPathInDBIf interface{}
@@ -298,7 +306,10 @@ func GetSeidByRefInDB(ref string) (seid uint64) {
 		logger.DataRepoLog.Warnln(getOneErr)
 	}
 	seidStr := result["seid"].(string)
-	seid, _ = strconv.ParseUint(seidStr, 16, 64)
+	seid, err := strconv.ParseUint(seidStr, 16, 64)
+	if err != nil {
+		logger.DataRepoLog.Errorf("seid unmarshall error: %v", err)
+	}
 	return
 }
 
@@ -394,7 +405,10 @@ func ClearSMContextInMem(ref string) {
 }
 
 func mapToByte(data map[string]interface{}) (ret []byte) {
-	ret, _ = json.Marshal(data)
+	ret, err := json.Marshal(data)
+	if err != nil {
+		logger.DataRepoLog.Errorf("map to byte error: %v", err)
+	}
 	return
 }
 

--- a/context/db.go
+++ b/context/db.go
@@ -160,12 +160,12 @@ func (smContext *SMContext) UnmarshalJSON(data []byte) error {
 		smContext.PFCPContext[key].PDRs = pfcpCtxInDB.PDRs
 		localSeid, err := strconv.ParseUint(pfcpCtxInDB.LocalSEID, 16, 64)
 		if err != nil {
-			logger.DataRepoLog.Errorf("LocalSEID unmarshall error: %v", err)
+			logger.DataRepoLog.Errorf("localSEID unmarshall error: %v", err)
 		}
 		smContext.PFCPContext[key].LocalSEID = localSeid
 		remoteSeid, err := strconv.ParseUint(pfcpCtxInDB.RemoteSEID, 16, 64)
 		if err != nil {
-			logger.DataRepoLog.Errorf("RemoteSEID unmarshall error: %v", err)
+			logger.DataRepoLog.Errorf("remoteSEID unmarshall error: %v", err)
 		}
 		smContext.PFCPContext[key].RemoteSEID = remoteSeid
 	}

--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -145,6 +145,6 @@ func (smContext *SMContext) HandlePDUSessionReleaseRequest(req *nasMessage.PDUSe
 	// Release UE IP Addr
 	err := smContext.ReleaseUeIpAddr()
 	if err != nil {
-		smContext.SubGsmLog.Errorf("Release UE IP Addr failed: %s", err)
+		smContext.SubGsmLog.Errorf("release UE IP Addr failed: %s", err)
 	}
 }

--- a/context/gsm_handler.go
+++ b/context/gsm_handler.go
@@ -143,5 +143,8 @@ func (smContext *SMContext) HandlePDUSessionReleaseRequest(req *nasMessage.PDUSe
 	smContext.Pti = req.GetPTI()
 
 	// Release UE IP Addr
-	smContext.ReleaseUeIpAddr()
+	err := smContext.ReleaseUeIpAddr()
+	if err != nil {
+		smContext.SubGsmLog.Errorf("Release UE IP Addr failed: %s", err)
+	}
 }

--- a/context/ip_allocator.go
+++ b/context/ip_allocator.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"strconv"
 	"sync"
+
+	"github.com/omec-project/smf/logger"
 )
 
 type IPAllocator struct {
@@ -93,7 +95,10 @@ func (a *IPAllocator) Allocate(imsi string) (net.IP, error) {
 		if smfCountStr == "" {
 			smfCountStr = "1"
 		}
-		smfCount, _ := strconv.Atoi(smfCountStr)
+		smfCount, err := strconv.Atoi(smfCountStr)
+		if err != nil {
+			logger.CtxLog.Errorf("Failed to convert SMF_COUNT to int: %v", err)
+		}
 		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)+(smfCount-1)*5000)
 		fmt.Printf("unique id - ip %v \n", ip)
 		fmt.Printf("unique id - offset %v \n", offset)

--- a/context/ip_allocator.go
+++ b/context/ip_allocator.go
@@ -97,7 +97,7 @@ func (a *IPAllocator) Allocate(imsi string) (net.IP, error) {
 		}
 		smfCount, err := strconv.Atoi(smfCountStr)
 		if err != nil {
-			logger.CtxLog.Errorf("Failed to convert SMF_COUNT to int: %v", err)
+			logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
 		}
 		ip := IPAddrWithOffset(a.ipNetwork.IP, int(offset)+(smfCount-1)*5000)
 		fmt.Printf("unique id - ip %v \n", ip)

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -319,7 +319,7 @@ func RemoveSMContext(ref string) {
 	// Release UE IP-Address
 	err := smContext.ReleaseUeIpAddr()
 	if err != nil {
-		smContext.SubCtxLog.Errorf("Release UE IP-Address failed, %v", err)
+		smContext.SubCtxLog.Errorf("release UE IP-Address failed, %v", err)
 	}
 
 	smContextPool.Delete(ref)
@@ -462,7 +462,7 @@ func (smContext *SMContext) AllocateLocalSEIDForDataPath(dataPath *DataPath) {
 		if _, exist := smContext.PFCPContext[NodeIDtoIP]; !exist {
 			allocatedSEID, err := AllocateLocalSEID()
 			if err != nil {
-				logger.PduSessLog.Errorf("AllocateLocalSEID failed, %v", err)
+				logger.PduSessLog.Errorf("allocateLocalSEID failed, %v", err)
 			}
 			smContext.PFCPContext[NodeIDtoIP] = &PFCPSessionContext{
 				PDRs:      make(map[uint16]*PDR),

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -715,7 +715,7 @@ func (smContext *SMContext) PublishSmCtxtInfo() {
 	// Send to stream
 	err := metrics.GetWriter().PublishPduSessEvent(kafkaSmCtxt, op)
 	if err != nil {
-		smContext.SubCtxLog.Errorf("Failed to publish sm ctxt info on kafka stream: %v", err)
+		smContext.SubCtxLog.Errorf("failed to publish sm ctxt info on kafka stream: %v", err)
 	}
 }
 

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -317,7 +317,10 @@ func RemoveSMContext(ref string) {
 	}
 
 	// Release UE IP-Address
-	smContext.ReleaseUeIpAddr()
+	err := smContext.ReleaseUeIpAddr()
+	if err != nil {
+		smContext.SubCtxLog.Errorf("Release UE IP-Address failed, %v", err)
+	}
 
 	smContextPool.Delete(ref)
 
@@ -457,7 +460,10 @@ func (smContext *SMContext) AllocateLocalSEIDForDataPath(dataPath *DataPath) {
 		NodeIDtoIP := curDataPathNode.UPF.NodeID.ResolveNodeIdToIp().String()
 		logger.PduSessLog.Traceln("NodeIDtoIP: ", NodeIDtoIP)
 		if _, exist := smContext.PFCPContext[NodeIDtoIP]; !exist {
-			allocatedSEID, _ := AllocateLocalSEID()
+			allocatedSEID, err := AllocateLocalSEID()
+			if err != nil {
+				logger.PduSessLog.Errorf("AllocateLocalSEID failed, %v", err)
+			}
 			smContext.PFCPContext[NodeIDtoIP] = &PFCPSessionContext{
 				PDRs:      make(map[uint16]*PDR),
 				NodeID:    curDataPathNode.UPF.NodeID,
@@ -652,7 +658,10 @@ func (smContext *SMContext) CommitSmPolicyDecision(status bool) error {
 	defer smContext.SMLock.Unlock()
 
 	if status {
-		qos.CommitSmPolicyDecision(&smContext.SmPolicyData, smContext.SmPolicyUpdates[0])
+		err := qos.CommitSmPolicyDecision(&smContext.SmPolicyData, smContext.SmPolicyUpdates[0])
+		if err != nil {
+			logger.CtxLog.Errorf("failed to commit SM Policy Decision, %v", err)
+		}
 	}
 
 	// Release 0th index update
@@ -704,7 +713,10 @@ func (smContext *SMContext) PublishSmCtxtInfo() {
 	kafkaSmCtxt.SmfIp = SMF_Self().PodIp
 
 	// Send to stream
-	metrics.GetWriter().PublishPduSessEvent(kafkaSmCtxt, op)
+	err := metrics.GetWriter().PublishPduSessEvent(kafkaSmCtxt, op)
+	if err != nil {
+		smContext.SubCtxLog.Errorf("Failed to publish sm ctxt info on kafka stream: %v", err)
+	}
 }
 
 func mapPduSessStateToMetricStateAndOp(state SMContextState) (string, mi.SubscriberOp) {

--- a/context/upf.go
+++ b/context/upf.go
@@ -298,7 +298,7 @@ func (upf *UPF) GenerateTEID() (uint32, error) {
 	smfCountStr := os.Getenv("SMF_COUNT")
 	smfCount, err := strconv.Atoi(smfCountStr)
 	if err != nil {
-		logger.CtxLog.Errorf("Failed to convert SMF_COUNT to int: %v", err)
+		logger.CtxLog.Errorf("failed to convert SMF_COUNT to int: %v", err)
 	}
 
 	offset := (smfCount - 1) * 5000

--- a/context/upf.go
+++ b/context/upf.go
@@ -296,7 +296,10 @@ func (upf *UPF) GenerateTEID() (uint32, error) {
 	// Assuming one SMF host 5000 UEs, this code gets offset = smfCount * 5000 and generate unique TEID
 
 	smfCountStr := os.Getenv("SMF_COUNT")
-	smfCount, _ := strconv.Atoi(smfCountStr)
+	smfCount, err := strconv.Atoi(smfCountStr)
+	if err != nil {
+		logger.CtxLog.Errorf("Failed to convert SMF_COUNT to int: %v", err)
+	}
 
 	offset := (smfCount - 1) * 5000
 	uniqueId := id + uint32(offset)

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -74,12 +74,18 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 
 	// Load UP Nodes to SMF
 	for name, node := range upTopology.UPNodes {
-		userplaneInformation.InsertSmfUserPlaneNode(name, &node)
+		err := userplaneInformation.InsertSmfUserPlaneNode(name, &node)
+		if err != nil {
+			logger.UPNodeLog.Errorf("Failed to insert UP Node[%v] ", node)
+		}
 	}
 
 	// Load UP Node Link config to SMF
 	for _, link := range upTopology.Links {
-		userplaneInformation.InsertUPNodeLinks(&link)
+		err := userplaneInformation.InsertUPNodeLinks(&link)
+		if err != nil {
+			logger.UPNodeLog.Errorf("Failed to insert UP Node link[%v] ", link)
+		}
 	}
 	return userplaneInformation
 }

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -76,7 +76,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 	for name, node := range upTopology.UPNodes {
 		err := userplaneInformation.InsertSmfUserPlaneNode(name, &node)
 		if err != nil {
-			logger.UPNodeLog.Errorf("Failed to insert UP Node[%v] ", node)
+			logger.UPNodeLog.Errorf("failed to insert UP Node[%v] ", node)
 		}
 	}
 
@@ -84,7 +84,7 @@ func NewUserPlaneInformation(upTopology *factory.UserPlaneInformation) *UserPlan
 	for _, link := range upTopology.Links {
 		err := userplaneInformation.InsertUPNodeLinks(&link)
 		if err != nil {
-			logger.UPNodeLog.Errorf("Failed to insert UP Node link[%v] ", link)
+			logger.UPNodeLog.Errorf("failed to insert UP Node link[%v] ", link)
 		}
 	}
 	return userplaneInformation

--- a/factory/config.go
+++ b/factory/config.go
@@ -305,7 +305,10 @@ func (c *Configuration) parseRocConfig(rsp *protos.NetworkSliceResponse) error {
 		// make SNSSAI
 		var sNssai models.Snssai
 		sNssai.Sd = ns.Nssai.Sd
-		numSst, _ := strconv.Atoi(ns.Nssai.Sst)
+		numSst, err := strconv.Atoi(ns.Nssai.Sst)
+		if err != nil {
+			logger.CtxLog.Errorf("Failed to convert SST to int : %v", ns.Nssai.Sst)
+		}
 		sNssai.Sst = int32(numSst)
 		sNssaiInfoItem.SNssai = &sNssai
 

--- a/factory/config.go
+++ b/factory/config.go
@@ -307,7 +307,7 @@ func (c *Configuration) parseRocConfig(rsp *protos.NetworkSliceResponse) error {
 		sNssai.Sd = ns.Nssai.Sd
 		numSst, err := strconv.Atoi(ns.Nssai.Sst)
 		if err != nil {
-			logger.CtxLog.Errorf("Failed to convert SST to int : %v", ns.Nssai.Sst)
+			logger.CtxLog.Errorf("failed to convert SST to int : %v", ns.Nssai.Sst)
 		}
 		sNssai.Sst = int32(numSst)
 		sNssaiInfoItem.SNssai = &sNssai

--- a/factory/config_test.go
+++ b/factory/config_test.go
@@ -24,11 +24,11 @@ func TestUpdateSliceInfo(t *testing.T) {
 
 	err := cfg1.parseRocConfig(makeDummyConfig("1", "010203"))
 	if err != nil {
-		t.Errorf("Error parsing config: %v", err)
+		t.Errorf("error parsing config: %v", err)
 	}
 	err = cfg2.parseRocConfig(makeDummyConfig("2", "010203"))
 	if err != nil {
-		t.Errorf("Error parsing config: %v", err)
+		t.Errorf("error parsing config: %v", err)
 	}
 
 	compareAndProcessConfigs(&cfg1, &cfg2)

--- a/factory/config_test.go
+++ b/factory/config_test.go
@@ -22,8 +22,14 @@ func TestUpdateSliceInfo(t *testing.T) {
 	cfg1 := Configuration{}
 	cfg2 := Configuration{}
 
-	cfg1.parseRocConfig(makeDummyConfig("1", "010203"))
-	cfg2.parseRocConfig(makeDummyConfig("2", "010203"))
+	err := cfg1.parseRocConfig(makeDummyConfig("1", "010203"))
+	if err != nil {
+		t.Errorf("Error parsing config: %v", err)
+	}
+	err = cfg2.parseRocConfig(makeDummyConfig("2", "010203"))
+	if err != nil {
+		t.Errorf("Error parsing config: %v", err)
+	}
 
 	compareAndProcessConfigs(&cfg1, &cfg2)
 }

--- a/fsm/handler.go
+++ b/fsm/handler.go
@@ -9,6 +9,7 @@ import (
 
 	mi "github.com/omec-project/metricfunc/pkg/metricinfo"
 	smf_context "github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/logger"
 	stats "github.com/omec-project/smf/metrics"
 	"github.com/omec-project/smf/producer"
 	"github.com/omec-project/smf/transaction"
@@ -92,13 +93,19 @@ func EmptyEventHandler(event SmEvent, eventData *SmEventData) (smf_context.SMCon
 
 func HandleStateInitEventPduSessCreate(event SmEvent, eventData *SmEventData) (smf_context.SMContextState, error) {
 	if err := producer.HandlePDUSessionSMContextCreate(eventData.Txn); err != nil {
-		stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_failure)
+		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_failure)
+		if err != nil {
+			logger.FsmLog.Errorf("Error while publishing pdu session create response failure, %v ", err.Error())
+		}
 		txn := eventData.Txn.(*transaction.Transaction)
 		txn.Err = err
 		return smf_context.SmStateInit, fmt.Errorf("pdu session create error, %v ", err.Error())
 	}
 
-	stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_success)
+	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_success)
+	if err != nil {
+		logger.FsmLog.Errorf("Error while publishing pdu session create response success, %v ", err.Error())
+	}
 	return smf_context.SmStatePfcpCreatePending, nil
 }
 
@@ -125,11 +132,17 @@ func HandleStateN1N2TransferPendingEventN1N2Transfer(event SmEvent, eventData *S
 	smCtxt := txn.Ctxt.(*smf_context.SMContext)
 
 	if err := producer.SendPduSessN1N2Transfer(smCtxt, true); err != nil {
-		stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_failure)
+		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_failure)
+		if err != nil {
+			smCtxt.SubFsmLog.Errorf("Error while publishing pdu session modify response failure, %v ", err.Error())
+		}
 		smCtxt.SubFsmLog.Errorf("N1N2 transfer failure error, %v ", err.Error())
 		return smf_context.SmStateN1N2TransferPending, fmt.Errorf("N1N2 Transfer failure error, %v ", err.Error())
 	}
-	stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_success)
+	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_success)
+	if err != nil {
+		smCtxt.SubFsmLog.Errorf("Error while publishing pdu session modify response success, %v ", err.Error())
+	}
 	return smf_context.SmStateActive, nil
 }
 
@@ -166,11 +179,17 @@ func HandleStateActiveEventPduSessRelease(event SmEvent, eventData *SmEventData)
 	smCtxt := txn.Ctxt.(*smf_context.SMContext)
 
 	if err := producer.HandlePDUSessionSMContextRelease(eventData.Txn); err != nil {
-		stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_failure)
+		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_failure)
+		if err != nil {
+			smCtxt.SubFsmLog.Errorf("Error while publishing pdu session release response failure, %v ", err.Error())
+		}
 		smCtxt.SubFsmLog.Errorf("sm context release error, %v ", err.Error())
 		return smf_context.SmStateInit, err
 	}
-	stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_success)
+	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_success)
+	if err != nil {
+		smCtxt.SubFsmLog.Errorf("Error while publishing pdu session release response success, %v ", err.Error())
+	}
 	return smf_context.SmStateInit, nil
 }
 

--- a/fsm/handler.go
+++ b/fsm/handler.go
@@ -95,7 +95,7 @@ func HandleStateInitEventPduSessCreate(event SmEvent, eventData *SmEventData) (s
 	if err := producer.HandlePDUSessionSMContextCreate(eventData.Txn); err != nil {
 		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_failure)
 		if err != nil {
-			logger.FsmLog.Errorf("Error while publishing pdu session create response failure, %v ", err.Error())
+			logger.FsmLog.Errorf("error while publishing pdu session create response failure, %v ", err.Error())
 		}
 		txn := eventData.Txn.(*transaction.Transaction)
 		txn.Err = err
@@ -104,7 +104,7 @@ func HandleStateInitEventPduSessCreate(event SmEvent, eventData *SmEventData) (s
 
 	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_create_rsp_success)
 	if err != nil {
-		logger.FsmLog.Errorf("Error while publishing pdu session create response success, %v ", err.Error())
+		logger.FsmLog.Errorf("error while publishing pdu session create response success, %v ", err.Error())
 	}
 	return smf_context.SmStatePfcpCreatePending, nil
 }
@@ -134,14 +134,14 @@ func HandleStateN1N2TransferPendingEventN1N2Transfer(event SmEvent, eventData *S
 	if err := producer.SendPduSessN1N2Transfer(smCtxt, true); err != nil {
 		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_failure)
 		if err != nil {
-			smCtxt.SubFsmLog.Errorf("Error while publishing pdu session modify response failure, %v ", err.Error())
+			smCtxt.SubFsmLog.Errorf("error while publishing pdu session modify response failure, %v ", err.Error())
 		}
 		smCtxt.SubFsmLog.Errorf("N1N2 transfer failure error, %v ", err.Error())
 		return smf_context.SmStateN1N2TransferPending, fmt.Errorf("N1N2 Transfer failure error, %v ", err.Error())
 	}
 	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_modify_rsp_success)
 	if err != nil {
-		smCtxt.SubFsmLog.Errorf("Error while publishing pdu session modify response success, %v ", err.Error())
+		smCtxt.SubFsmLog.Errorf("error while publishing pdu session modify response success, %v ", err.Error())
 	}
 	return smf_context.SmStateActive, nil
 }
@@ -181,14 +181,14 @@ func HandleStateActiveEventPduSessRelease(event SmEvent, eventData *SmEventData)
 	if err := producer.HandlePDUSessionSMContextRelease(eventData.Txn); err != nil {
 		err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_failure)
 		if err != nil {
-			smCtxt.SubFsmLog.Errorf("Error while publishing pdu session release response failure, %v ", err.Error())
+			smCtxt.SubFsmLog.Errorf("error while publishing pdu session release response failure, %v ", err.Error())
 		}
 		smCtxt.SubFsmLog.Errorf("sm context release error, %v ", err.Error())
 		return smf_context.SmStateInit, err
 	}
 	err := stats.PublishMsgEvent(mi.Smf_msg_type_pdu_sess_release_rsp_success)
 	if err != nil {
-		smCtxt.SubFsmLog.Errorf("Error while publishing pdu session release response success, %v ", err.Error())
+		smCtxt.SubFsmLog.Errorf("error while publishing pdu session release response success, %v ", err.Error())
 	}
 	return smf_context.SmStateInit, nil
 }
@@ -198,7 +198,7 @@ func HandleStateActiveEventPduSessN1N2TransFailInd(event SmEvent, eventData *SmE
 	smCtxt := txn.Ctxt.(*smf_context.SMContext)
 
 	if err := producer.HandlePduSessN1N2TransFailInd(eventData.Txn); err != nil {
-		smCtxt.SubFsmLog.Errorf("Error while processing HandlePduSessN1N2TransferFailureIndication, %v ", err.Error())
+		smCtxt.SubFsmLog.Errorf("error while processing HandlePduSessN1N2TransferFailureIndication, %v ", err.Error())
 		return smf_context.SmStateInit, err
 	}
 	return smf_context.SmStateInit, nil

--- a/fsm/txnFsm.go
+++ b/fsm/txnFsm.go
@@ -35,11 +35,20 @@ func (SmfTxnFsm) TxnLoadCtxt(txn *transaction.Transaction) (transaction.TxnEvent
 		createData := req.JsonData
 		if smCtxtRef, err := smf_context.ResolveRef(createData.Supi, createData.PduSessionId); err == nil {
 			// Previous context exist
-			producer.HandlePduSessionContextReplacement(smCtxtRef)
+			err := producer.HandlePduSessionContextReplacement(smCtxtRef)
+			if err != nil {
+				txn.TxnFsmLog.Errorf("handle event[%v], next-event[%v], error[%v] ",
+					transaction.TxnEventLoadCtxt.String(), transaction.TxnEventFailure.String(), err)
+			}
 		}
 		// Create fresh context
 		txn.Ctxt = smf_context.NewSMContext(createData.Supi, createData.PduSessionId)
-		txn.CtxtKey, _ = smf_context.ResolveRef(createData.Supi, createData.PduSessionId)
+		CtxtKey, err := smf_context.ResolveRef(createData.Supi, createData.PduSessionId)
+		if err != nil {
+			txn.TxnFsmLog.Errorf("handle event[%v], next-event[%v], error[%v] ",
+				transaction.TxnEventLoadCtxt.String(), transaction.TxnEventFailure.String(), err)
+		}
+		txn.CtxtKey = CtxtKey
 	case svcmsgtypes.UpdateSmContext:
 		fallthrough
 	case svcmsgtypes.ReleaseSmContext:

--- a/metrics/kafka.go
+++ b/metrics/kafka.go
@@ -84,7 +84,10 @@ func (writer Writer) PublishPduSessEvent(ctxt mi.CoreSubscriber, op mi.Subscribe
 		return err
 	} else {
 		logger.KafkaLog.Debugf("publishing pdu sess event[%s] ", msg)
-		StatWriter.SendMessage(msg)
+		err := StatWriter.SendMessage(msg)
+		if err != nil {
+			logger.KafkaLog.Errorf("publishing pdu sess event error [%v] ", err.Error())
+		}
 	}
 	return nil
 }
@@ -106,7 +109,10 @@ func PublishMsgEvent(msgType mi.SmfMsgType) error {
 		return err
 	} else {
 		logger.KafkaLog.Debugf("publishing msg event[%s] ", msg)
-		StatWriter.SendMessage(msg)
+		err := StatWriter.SendMessage(msg)
+		if err != nil {
+			logger.KafkaLog.Errorf("publishing msg event error [%v] ", err.Error())
+		}
 	}
 	return nil
 }
@@ -118,7 +124,10 @@ func (writer Writer) PublishNfStatusEvent(msgEvent mi.MetricEvent) error {
 		return err
 	} else {
 		logger.KafkaLog.Debugf("publishing nf status event[%s] ", msg)
-		StatWriter.SendMessage(msg)
+		err := StatWriter.SendMessage(msg)
+		if err != nil {
+			logger.KafkaLog.Errorf("publishing nf status event error [%v] ", err.Error())
+		}
 	}
 	return nil
 }

--- a/metrics/kafka_test.go
+++ b/metrics/kafka_test.go
@@ -40,7 +40,10 @@ func TestSendMessageWithKafkaDisabled(t *testing.T) {
 	}
 	factory.SmfConfig = config
 
-	InitialiseKafkaStream(&configuration)
+	err := InitialiseKafkaStream(&configuration)
+	if err != nil {
+		t.Errorf("Expected return value to be nil, got %v", err)
+	}
 
 	writer := GetWriter()
 
@@ -63,7 +66,10 @@ func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
 	}
 	factory.SmfConfig = config
 
-	InitialiseKafkaStream(&configuration)
+	err := InitialiseKafkaStream(&configuration)
+	if err != nil {
+		t.Errorf("Expected return value to be nil, got %v", err)
+	}
 
 	writer := GetWriter()
 
@@ -86,7 +92,10 @@ func TestPublishMsgEventWithKafkaDisabled(t *testing.T) {
 	}
 	factory.SmfConfig = config
 
-	InitialiseKafkaStream(&configuration)
+	err := InitialiseKafkaStream(&configuration)
+	if err != nil {
+		t.Errorf("Expected return value to be nil, got %v", err)
+	}
 
 	// If the kafkaWriter is called, this will panic and fail the test
 	result := PublishMsgEvent(0)
@@ -107,7 +116,10 @@ func TestPublishNfStatusWithKafkaDisabled(t *testing.T) {
 	}
 	factory.SmfConfig = config
 
-	InitialiseKafkaStream(&configuration)
+	err := InitialiseKafkaStream(&configuration)
+	if err != nil {
+		t.Errorf("Expected return value to be nil, got %v", err)
+	}
 
 	writer := GetWriter()
 

--- a/metrics/kafka_test.go
+++ b/metrics/kafka_test.go
@@ -22,10 +22,10 @@ func TestInitializeKafkaStreamWithKafkaDisabled(t *testing.T) {
 	result := InitialiseKafkaStream(&config)
 
 	if result != nil {
-		t.Errorf("Expected return value to be nil, got %v", result)
+		t.Errorf("expected return value to be nil, got %v", result)
 	}
 	if StatWriter.kafkaWriter != nil {
-		t.Errorf("Expected kafkaWrite to be nil, got %v", StatWriter.kafkaWriter)
+		t.Errorf("expected kafkaWrite to be nil, got %v", StatWriter.kafkaWriter)
 	}
 }
 
@@ -42,7 +42,7 @@ func TestSendMessageWithKafkaDisabled(t *testing.T) {
 
 	err := InitialiseKafkaStream(&configuration)
 	if err != nil {
-		t.Errorf("Expected return value to be nil, got %v", err)
+		t.Errorf("expected return value to be nil, got %v", err)
 	}
 
 	writer := GetWriter()
@@ -51,7 +51,7 @@ func TestSendMessageWithKafkaDisabled(t *testing.T) {
 	result := writer.SendMessage([]byte{0xFF})
 
 	if result != nil {
-		t.Errorf("Expected return value to be nil, got %v", result)
+		t.Errorf("expected return value to be nil, got %v", result)
 	}
 }
 
@@ -68,7 +68,7 @@ func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
 
 	err := InitialiseKafkaStream(&configuration)
 	if err != nil {
-		t.Errorf("Expected return value to be nil, got %v", err)
+		t.Errorf("expected return value to be nil, got %v", err)
 	}
 
 	writer := GetWriter()
@@ -77,7 +77,7 @@ func TestPublishPduSessEventWithKafkaDisabled(t *testing.T) {
 	result := writer.PublishPduSessEvent(metricinfo.CoreSubscriber{}, 0)
 
 	if result != nil {
-		t.Errorf("Expected return value to be nil, got %v", result)
+		t.Errorf("expected return value to be nil, got %v", result)
 	}
 }
 
@@ -94,14 +94,14 @@ func TestPublishMsgEventWithKafkaDisabled(t *testing.T) {
 
 	err := InitialiseKafkaStream(&configuration)
 	if err != nil {
-		t.Errorf("Expected return value to be nil, got %v", err)
+		t.Errorf("expected return value to be nil, got %v", err)
 	}
 
 	// If the kafkaWriter is called, this will panic and fail the test
 	result := PublishMsgEvent(0)
 
 	if result != nil {
-		t.Errorf("Expected return value to be nil, got %v", result)
+		t.Errorf("expected return value to be nil, got %v", result)
 	}
 }
 
@@ -118,7 +118,7 @@ func TestPublishNfStatusWithKafkaDisabled(t *testing.T) {
 
 	err := InitialiseKafkaStream(&configuration)
 	if err != nil {
-		t.Errorf("Expected return value to be nil, got %v", err)
+		t.Errorf("expected return value to be nil, got %v", err)
 	}
 
 	writer := GetWriter()
@@ -127,6 +127,6 @@ func TestPublishNfStatusWithKafkaDisabled(t *testing.T) {
 	result := writer.PublishNfStatusEvent(metricinfo.MetricEvent{})
 
 	if result != nil {
-		t.Errorf("Expected return value to be nil, got %v", result)
+		t.Errorf("expected return value to be nil, got %v", result)
 	}
 }

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -107,7 +107,7 @@ func InitMetrics() {
 	http.Handle("/metrics", promhttp.Handler())
 	err := http.ListenAndServe(":9089", nil)
 	if err != nil {
-		log.Fatalf("Failed to start metrics server: %v", err)
+		log.Fatalf("failed to start metrics server: %v", err)
 	}
 }
 

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -105,7 +105,10 @@ func init() {
 // InitMetrics initialises SMF stats
 func InitMetrics() {
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":9089", nil)
+	err := http.ListenAndServe(":9089", nil)
+	if err != nil {
+		log.Fatalf("Failed to start metrics server: %v", err)
+	}
 }
 
 // IncrementN11MsgStats increments message level stats

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -102,7 +102,10 @@ func HandlePfcpHeartbeatResponse(msg *udp.Message) {
 				NfStatus: mi.NfStatusConnected, NfName: string(upf.NodeID.NodeIdValue),
 			},
 		}
-		metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+		err := metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+		if err != nil {
+			logger.PfcpLog.Errorf("failed to publish NfStatusEvent: %+v", err)
+		}
 	}
 
 	upf.NHeartBeat = 0 // reset Heartbeat attempt to 0
@@ -276,7 +279,10 @@ func HandlePfcpAssociationSetupResponse(msg *udp.Message) {
 					NfStatus: mi.NfStatusConnected, NfName: string(upf.NodeID.NodeIdValue),
 				},
 			}
-			metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+			err := metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+			if err != nil {
+				logger.PfcpLog.Errorf("failed to publish NfStatusEvent: %+v", err)
+			}
 		}
 
 		// Supported Features of UPF
@@ -461,7 +467,10 @@ func HandlePfcpSessionEstablishmentResponse(msg *udp.Message) {
 		smContext.SubPfcpLog.Infof("upf provided ue ip address [%v]", ueIPAddress)
 
 		// Release previous locally allocated UE IP-Addr
-		smContext.ReleaseUeIpAddr()
+		err := smContext.ReleaseUeIpAddr()
+		if err != nil {
+			logger.PfcpLog.Errorf("failed to release UE IP-Addr: %+v", err)
+		}
 
 		// Update with one received from UPF
 		smContext.PDUAddress.Ip = ueIPAddress

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -38,8 +38,12 @@ const UPFAdapterURL = "http://upf-adapter:8090"
 
 func getSeqNumber() uint32 {
 	smfCount := 1
+	var err error
 	if smfCountStr, ok := os.LookupEnv("SMF_COUNT"); ok {
-		smfCount, _ = strconv.Atoi(smfCountStr)
+		smfCount, err = strconv.Atoi(smfCountStr)
+		if err != nil {
+			logger.PfcpLog.Errorf("SMF_COUNT env variable is not a number: %v", smfCountStr)
+		}
 	}
 
 	seqNum := atomic.AddUint32(&seq, 1) + uint32((smfCount-1)*5000)
@@ -84,7 +88,11 @@ func SendHeartbeatRequest(upNodeID smf_context.NodeID, upfPort uint16) error {
 			return err
 		} else {
 			logger.PfcpLog.Debugf("send pfcp heartbeat response [%v] ", rsp)
-			defer rsp.Body.Close()
+			defer func() {
+				if err = rsp.Body.Close(); err != nil {
+					logger.PfcpLog.Errorf("close response body failed: %v", err)
+				}
+			}()
 			if rsp.StatusCode == http.StatusOK {
 				pfcpMsgBytes, err := io.ReadAll(rsp.Body)
 				if err != nil {
@@ -98,7 +106,10 @@ func SendHeartbeatRequest(upNodeID smf_context.NodeID, upfPort uint16) error {
 					logger.PfcpLog.Errorf("parse pfcp heartbeat response failed: %v", err)
 					return err
 				}
-				adapter.HandleAdapterPfcpRsp(pfcpRspMsg, nil)
+				err = adapter.HandleAdapterPfcpRsp(pfcpRspMsg, nil)
+				if err != nil {
+					logger.PfcpLog.Errorf("handle adapter pfcp response failed: %v", err)
+				}
 			}
 		}
 	} else {
@@ -123,7 +134,10 @@ func SendPfcpAssociationSetupRequest(upNodeID smf_context.NodeID, upfPort uint16
 				NfStatus: mi.NfStatusDisconnected, NfName: string(upNodeID.NodeIdValue),
 			},
 		}
-		metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+		err := metrics.StatWriter.PublishNfStatusEvent(upfStatus)
+		if err != nil {
+			logger.PfcpLog.Errorf("Failed to publish UPF status event: %v", err)
+		}
 	}
 
 	if net.IP.Equal(upNodeID.ResolveNodeIdToIp(), net.IPv4zero) {
@@ -154,7 +168,10 @@ func SendPfcpAssociationSetupRequest(upNodeID smf_context.NodeID, upfPort uint16
 					logger.PfcpLog.Errorf("parse pfcp association response failed: %v", err)
 					return err
 				}
-				adapter.HandleAdapterPfcpRsp(pfcpRspMsg, nil)
+				err = adapter.HandleAdapterPfcpRsp(pfcpRspMsg, nil)
+				if err != nil {
+					logger.PfcpLog.Errorf("handle adapter pfcp response failed: %v", err)
+				}
 			}
 		}
 	} else {
@@ -256,7 +273,10 @@ func SendPfcpSessionEstablishmentRequest(
 					return err
 				}
 				eventData := udp.PfcpEventData{LSEID: ctx.PFCPContext[ip.String()].LocalSEID, ErrHandler: HandlePfcpSendError}
-				adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				err = adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				if err != nil {
+					logger.PfcpLog.Errorf("handle adapter pfcp response failed: %v", err)
+				}
 			} else {
 				// http status !OK
 				HandlePfcpSendError(pfcpMsg, fmt.Errorf("send error to upf-adapter [%v]", rsp.StatusCode))
@@ -318,7 +338,10 @@ func SendPfcpSessionModificationRequest(
 					return err
 				}
 				eventData := udp.PfcpEventData{LSEID: ctx.PFCPContext[nodeIDtoIP].LocalSEID, ErrHandler: HandlePfcpSendError}
-				adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				err = adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				if err != nil {
+					logger.PfcpLog.Errorf("handle adapter pfcp response failed: %v", err)
+				}
 			}
 		}
 	} else {
@@ -366,7 +389,10 @@ func SendPfcpSessionDeletionRequest(upNodeID smf_context.NodeID, ctx *smf_contex
 					return err
 				}
 				eventData := udp.PfcpEventData{LSEID: pfcpContext.LocalSEID, ErrHandler: HandlePfcpSendError}
-				adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				err = adapter.HandleAdapterPfcpRsp(pfcpRspMsg, &eventData)
+				if err != nil {
+					logger.PfcpLog.Errorf("handle adapter pfcp response failed: %v", err)
+				}
 			}
 		}
 	} else {

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -136,7 +136,7 @@ func SendPfcpAssociationSetupRequest(upNodeID smf_context.NodeID, upfPort uint16
 		}
 		err := metrics.StatWriter.PublishNfStatusEvent(upfStatus)
 		if err != nil {
-			logger.PfcpLog.Errorf("Failed to publish UPF status event: %v", err)
+			logger.PfcpLog.Errorf("failed to publish UPF status event: %v", err)
 		}
 	}
 

--- a/pfcp/message/send_test.go
+++ b/pfcp/message/send_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -52,7 +53,12 @@ func TestSendPfcpAssociationSetupRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
-	defer conn.Close()
+
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -74,7 +80,12 @@ func TestSendPfcpAssociationSetupResponse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
-	defer conn.Close()
+
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -130,7 +141,12 @@ func TestSendPfcpSessionEstablishmentRequestUpNodeExists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
-	defer conn.Close()
+
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -171,7 +187,12 @@ func TestSendPfcpSessionEstablishmentRequestUpNodeDoesNotExist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
-	defer conn.Close()
+
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -221,7 +242,12 @@ func TestSendPfcpSessionModificationRequest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
-	defer conn.Close()
+
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -267,7 +293,11 @@ func TestSendPfcpSessionDeletionRequest(t *testing.T) {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
 
-	defer conn.Close()
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -296,7 +326,11 @@ func TestSendPfcpSessionReportResponse(t *testing.T) {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
 
-	defer conn.Close()
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -332,7 +366,11 @@ func TestSendHeartbeatRequest(t *testing.T) {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
 
-	defer conn.Close()
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,
@@ -361,7 +399,11 @@ func TestSendHeartbeatResponse(t *testing.T) {
 		t.Fatalf("error listening on UDP: %v", err)
 	}
 
-	defer conn.Close()
+	defer func() {
+		if err = conn.Close(); err != nil {
+			log.Printf("error closing connection: %v", err)
+		}
+	}()
 
 	udp.Server = &udp.PfcpServer{
 		Conn: conn,

--- a/pfcp/udp/udp.go
+++ b/pfcp/udp/udp.go
@@ -144,7 +144,7 @@ func readPfcpMessage() (*net.UDPAddr, message.Message, interface{}, error) {
 
 	msg, err := message.Parse(buf[:n])
 	if err != nil {
-		logger.PfcpLog.Errorf("Error parsing PFCP message: %v", err)
+		logger.PfcpLog.Errorf("error parsing PFCP message: %v", err)
 		return addr, nil, nil, err
 	}
 

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -761,7 +761,7 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 		// Sending PFCP modification with flag set to DROP the packets.
 		err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext, pdrList, farList, barList, qerList, ANUPF.UPF.Port)
 		if err != nil {
-			smContext.SubPduSessLog.Errorf("PFCP Session Modification Request failed: %v", err)
+			smContext.SubPduSessLog.Errorf("pfcp Session Modification Request failed: %v", err)
 		}
 	}
 

--- a/producer/sm_pfcp_handling.go
+++ b/producer/sm_pfcp_handling.go
@@ -15,8 +15,11 @@ import (
 func SendPfcpSessionModifyReq(smContext *smf_context.SMContext, pfcpParam *pfcpParam) error {
 	defaultPath := smContext.Tunnel.DataPathPool.GetDefaultPath()
 	ANUPF := defaultPath.FirstDPNode
-	pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext,
+	err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext,
 		pfcpParam.pdrList, pfcpParam.farList, pfcpParam.barList, pfcpParam.qerList, ANUPF.UPF.Port)
+	if err != nil {
+		smContext.SubCtxLog.Errorf("PDUSessionSMContextUpdate, PFCP Session Modification Failure: %+v", err)
+	}
 
 	PFCPResponseStatus := <-smContext.SBIPFCPCommunicationChan
 

--- a/producer/sm_pfcp_handling.go
+++ b/producer/sm_pfcp_handling.go
@@ -18,7 +18,7 @@ func SendPfcpSessionModifyReq(smContext *smf_context.SMContext, pfcpParam *pfcpP
 	err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext,
 		pfcpParam.pdrList, pfcpParam.farList, pfcpParam.barList, pfcpParam.qerList, ANUPF.UPF.Port)
 	if err != nil {
-		smContext.SubCtxLog.Errorf("PDUSessionSMContextUpdate, PFCP Session Modification Failure: %+v", err)
+		smContext.SubCtxLog.Errorf("pfcp session modification failure: %+v", err)
 	}
 
 	PFCPResponseStatus := <-smContext.SBIPFCPCommunicationChan

--- a/producer/ulcl_procedure.go
+++ b/producer/ulcl_procedure.go
@@ -33,7 +33,10 @@ func AddPDUSessionAnchorAndULCL(smContext *context.SMContext, nodeID context.Nod
 		}
 
 		// Allocate Path PDR and TEID
-		bpMGR.ActivatingPath.ActivateTunnelAndPDR(smContext, 255)
+		err = bpMGR.ActivatingPath.ActivateTunnelAndPDR(smContext, 255)
+		if err != nil {
+			logger.PduSessLog.Errorln(err)
+		}
 		// N1N2MessageTransfer Here
 
 		// Establish PSA2
@@ -221,7 +224,10 @@ func EstablishULCL(smContext *context.SMContext) {
 
 			curDPNodeIP := ulcl.NodeID.ResolveNodeIdToIp().String()
 			bpMGR.PendingUPF[curDPNodeIP] = true
-			message.SendPfcpSessionModificationRequest(ulcl.NodeID, smContext, pdrList, farList, barList, qerList, ulcl.Port)
+			err = message.SendPfcpSessionModificationRequest(ulcl.NodeID, smContext, pdrList, farList, barList, qerList, ulcl.Port)
+			if err != nil {
+				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, ulcl.NodeID, ulcl.NodeID.ResolveNodeIdToIp())
+			}
 			break
 		}
 	}
@@ -258,8 +264,11 @@ func UpdatePSA2DownLink(smContext *context.SMContext) {
 
 				curDPNodeIP := curDataPathNode.UPF.NodeID.ResolveNodeIdToIp().String()
 				bpMGR.PendingUPF[curDPNodeIP] = true
-				message.SendPfcpSessionModificationRequest(
+				err := message.SendPfcpSessionModificationRequest(
 					curDataPathNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, curDataPathNode.UPF.Port)
+				if err != nil {
+					logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, curDataPathNode.UPF.NodeID, curDataPathNode.UPF.NodeID.ResolveNodeIdToIp())
+				}
 				logger.PfcpLog.Info("[SMF] Update PSA2 downlink msg has been send")
 				break
 			}
@@ -373,7 +382,10 @@ func UpdateRANAndIUPFUpLink(smContext *context.SMContext) {
 
 			curDPNodeIP := curDPNode.UPF.NodeID.ResolveNodeIdToIp().String()
 			bpMGR.PendingUPF[curDPNodeIP] = true
-			message.SendPfcpSessionModificationRequest(curDPNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, curDPNode.UPF.Port)
+			err := message.SendPfcpSessionModificationRequest(curDPNode.UPF.NodeID, smContext, pdrList, farList, barList, qerList, curDPNode.UPF.Port)
+			if err != nil {
+				logger.PduSessLog.Errorf("send pfcp session modification request failed: %v for UPF[%v, %v]: ", err, curDPNode.UPF.NodeID, curDPNode.UPF.NodeID.ResolveNodeIdToIp())
+			}
 		}
 	}
 

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -259,7 +259,7 @@ func DecodeFlowDescToIPFilters(flowDesc string) *IPFilterRule {
 	// decode source IP/mask
 	err := ipfRule.decodeIpFilterAddrv4(true, pfcTags[4])
 	if err != nil {
-		logger.QosLog.Errorf("Error decoding source IP/mask: %s", err)
+		logger.QosLog.Errorf("error decoding source IP/mask: %s", err)
 	}
 
 	// decode source port/port-range (optional)
@@ -267,13 +267,13 @@ func DecodeFlowDescToIPFilters(flowDesc string) *IPFilterRule {
 		// decode source port/port-range
 		err := ipfRule.decodeIpFilterPortInfo(true, pfcTags[5])
 		if err != nil {
-			logger.QosLog.Errorf("Error decoding source port/port-range: %s", err)
+			logger.QosLog.Errorf("error decoding source port/port-range: %s", err)
 		}
 
 		// decode destination IP/mask
 		err = ipfRule.decodeIpFilterAddrv4(false, pfcTags[7])
 		if err != nil {
-			logger.QosLog.Errorf("Error decoding destination IP/mask: %s", err)
+			logger.QosLog.Errorf("error decoding destination IP/mask: %s", err)
 		}
 
 		// decode destination port/port-range(optional), if any

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -280,21 +280,21 @@ func DecodeFlowDescToIPFilters(flowDesc string) *IPFilterRule {
 		if len(pfcTags) == 9 {
 			err := ipfRule.decodeIpFilterPortInfo(false, pfcTags[8])
 			if err != nil {
-				logger.QosLog.Errorf("Error decoding destination port/port-range: %s", err)
+				logger.QosLog.Errorf("error decoding destination port/port-range: %s", err)
 			}
 		}
 	} else {
 		// decode destination IP/mask
 		err := ipfRule.decodeIpFilterAddrv4(false, pfcTags[6])
 		if err != nil {
-			logger.QosLog.Errorf("Error decoding destination IP/mask: %s", err)
+			logger.QosLog.Errorf("error decoding destination IP/mask: %s", err)
 		}
 
 		// decode destination port/port-range(optional), if any
 		if len(pfcTags) == 8 {
 			err := ipfRule.decodeIpFilterPortInfo(false, pfcTags[7])
 			if err != nil {
-				logger.QosLog.Errorf("Error decoding destination port/port-range: %s", err)
+				logger.QosLog.Errorf("error decoding destination port/port-range: %s", err)
 			}
 		}
 	}

--- a/service/init.go
+++ b/service/init.go
@@ -134,7 +134,10 @@ func (smf *SMF) Initialize(c *cli.Context) error {
 	if factory.SmfConfig.Configuration.DebugProfilePort != 0 {
 		addr := fmt.Sprintf(":%d", factory.SmfConfig.Configuration.DebugProfilePort)
 		go func() {
-			http.ListenAndServe(addr, nil)
+			err := http.ListenAndServe(addr, nil)
+			if err != nil {
+				initLog.Warnf("start profiling server failed: %+v", err)
+			}
 		}()
 	}
 

--- a/upfadapter/pfcp/udp/udp.go
+++ b/upfadapter/pfcp/udp/udp.go
@@ -139,7 +139,7 @@ func readPfcpMessage() (message.Message, error) {
 
 	msg, err := message.Parse(buf[:n])
 	if err != nil {
-		logger.PfcpLog.Errorf("Error parsing PFCP message: %v", err)
+		logger.PfcpLog.Errorf("error parsing PFCP message: %v", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

Here we activate the golangci `errcheck` linter and check the corresponding errors that were flagged by the check. 

Note that we typically only log those messages here so that the change does not include potential behaviour changes. In practice this should mean better logs when unexpected situation occur in the SMF.

Note: Further PR's will be created to enable other linters.
