### PR TITLE
chore: enable `unparam`, `noctx`, and `nakedret` linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -252,7 +252,7 @@ linters:
     # - gocognit
     # - nestif
     # - gomodguard
-    # - nakedret
+    - nakedret
     - gci
     - misspell
     - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -259,7 +259,7 @@ linters:
     - whitespace
     - unconvert
     # - predeclared
-    # - noctx
+    - noctx
     - dogsled
     # - bodyclose
     - asciicheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -264,7 +264,7 @@ linters:
     # - bodyclose
     - asciicheck
       #- stylecheck
-      # - unparam
+    - unparam
       # - wsl
 
   #disable-all: false

--- a/context/config.go
+++ b/context/config.go
@@ -29,7 +29,7 @@ func (c *SMFContext) insertSmfNssaiInfo(snssaiInfoConfig *factory.SnssaiInfoItem
 		logger.InitLog.Errorf("network slice [%v] already exist, deleting", factory.PrettyPrintNetworkSlices([]factory.SnssaiInfoItem{*snssaiInfoConfig}))
 		err := c.deleteSmfNssaiInfo(snssaiInfoConfig)
 		if err != nil {
-			logger.InitLog.Errorf("network slice delete error %v", err)
+			return fmt.Errorf("network slice delete error %v", err)
 		}
 	}
 
@@ -80,11 +80,11 @@ func (c *SMFContext) updateSmfNssaiInfo(modSliceInfo *factory.SnssaiInfoItem) er
 	// identify slices to be updated
 	logger.InitLog.Infof("Network Slices to be modified [%v] ", factory.PrettyPrintNetworkSlices([]factory.SnssaiInfoItem{*modSliceInfo}))
 	if err := c.deleteSmfNssaiInfo(modSliceInfo); err != nil {
-		logger.InitLog.Errorf("network slice delete error %v", err)
+		return fmt.Errorf("network slice delete error %v", err)
 	}
 
 	if err := c.insertSmfNssaiInfo(modSliceInfo); err != nil {
-		logger.InitLog.Errorf("network slice insert error %v", err)
+		return fmt.Errorf("network slice insert error %v", err)
 	}
 	return nil
 }

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -251,7 +251,7 @@ func getPathBetween(cur *UPNode, dest *UPNode, visited map[*UPNode]bool,
 		path = make([]*UPNode, 0)
 		path = append(path, cur)
 		pathExist = true
-		return
+		return path, pathExist
 	}
 
 	selectedSNssai := selection.SNssai
@@ -272,7 +272,7 @@ func getPathBetween(cur *UPNode, dest *UPNode, visited map[*UPNode]bool,
 				path = append(path, path_tail...)
 				pathExist = true
 
-				return
+				return path, pathExist
 			}
 		}
 	}

--- a/factory/config.go
+++ b/factory/config.go
@@ -291,7 +291,7 @@ func (c *Configuration) parseRocConfig(rsp *protos.NetworkSliceResponse) error {
 	pfcpPortVal := DEFAULT_PFCP_PORT
 	if pfcpPortStr != "" {
 		if val, err := strconv.ParseUint(pfcpPortStr, 10, 32); err != nil {
-			logger.CtxLog.Infoln("Parse pfcp port failed : ", pfcpPortStr)
+			return fmt.Errorf("parse pfcp port failed : %v", pfcpPortStr)
 		} else {
 			pfcpPortVal = int(val)
 		}

--- a/factory/config.go
+++ b/factory/config.go
@@ -588,7 +588,7 @@ func compareNetworkSlices(slice1, slice2 []SnssaiInfoItem) (match bool, add, mod
 			slice1, slice2 = slice2, slice1
 		}
 	}
-	return
+	return match, add, mod, del
 }
 
 func compareUPNetworkSlices(slice1, slice2 []models.SnssaiUpfInfoItem) (match bool, add, mod, del []models.SnssaiUpfInfoItem) {
@@ -626,7 +626,7 @@ func compareUPNetworkSlices(slice1, slice2 []models.SnssaiUpfInfoItem) (match bo
 			slice1, slice2 = slice2, slice1
 		}
 	}
-	return
+	return match, add, mod, del
 }
 
 func compareGenericSlices(t1, t2 interface{}, compare func(i, j interface{}) bool) (match bool, add, remove interface{}) {

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -354,14 +354,12 @@ func HandlePfcpAssociationReleaseRequest(msg *udp.Message) {
 	nodeID := smf_context.NewNodeID(nodeIDStr)
 
 	upf := smf_context.RetrieveUPFNodeByNodeID(*nodeID)
-	var cause uint8
-	if upf != nil {
-		smf_context.RemoveUPFNodeByNodeID(*nodeID)
-		cause = ie.CauseRequestAccepted
-	} else {
-		cause = ie.CauseNoEstablishedPFCPAssociation
+	if upf == nil {
+		logger.PfcpLog.Errorf("can't find UPF[%s]", nodeIDStr)
+		return
 	}
-
+	smf_context.RemoveUPFNodeByNodeID(*nodeID)
+	cause := ie.CauseRequestAccepted
 	err = pfcp_message.SendPfcpAssociationReleaseResponse(*nodeID, cause, upf.Port)
 	if err != nil {
 		logger.PfcpLog.Errorf("failed to send PFCP Association Release Response: %+v", err)

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -598,7 +598,8 @@ func SendPfcpMsgToAdapter(upNodeID smf_context.NodeID, msg message.Message, addr
 	logger.PfcpLog.Debugf("send to :%s\n", url)
 
 	bodyReader := bytes.NewReader(udpPodMsgJson)
-	req, err := http.NewRequest(http.MethodPost, url, bodyReader)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bodyReader)
 	if err != nil {
 		logger.PfcpLog.Errorf("client: could not create request: %s\n", err)
 	}

--- a/qos/qos_rule.go
+++ b/qos/qos_rule.go
@@ -257,45 +257,27 @@ func DecodeFlowDescToIPFilters(flowDesc string) *IPFilterRule {
 	ipfRule.protoId = pfcTags[2]
 
 	// decode source IP/mask
-	err := ipfRule.decodeIpFilterAddrv4(true, pfcTags[4])
-	if err != nil {
-		logger.QosLog.Errorf("error decoding source IP/mask: %s", err)
-	}
+	ipfRule.decodeIpFilterAddrv4(true, pfcTags[4])
 
 	// decode source port/port-range (optional)
 	if pfcTags[6] == "to" {
 		// decode source port/port-range
-		err := ipfRule.decodeIpFilterPortInfo(true, pfcTags[5])
-		if err != nil {
-			logger.QosLog.Errorf("error decoding source port/port-range: %s", err)
-		}
+		ipfRule.decodeIpFilterPortInfo(true, pfcTags[5])
 
 		// decode destination IP/mask
-		err = ipfRule.decodeIpFilterAddrv4(false, pfcTags[7])
-		if err != nil {
-			logger.QosLog.Errorf("error decoding destination IP/mask: %s", err)
-		}
+		ipfRule.decodeIpFilterAddrv4(false, pfcTags[7])
 
 		// decode destination port/port-range(optional), if any
 		if len(pfcTags) == 9 {
-			err := ipfRule.decodeIpFilterPortInfo(false, pfcTags[8])
-			if err != nil {
-				logger.QosLog.Errorf("error decoding destination port/port-range: %s", err)
-			}
+			ipfRule.decodeIpFilterPortInfo(false, pfcTags[8])
 		}
 	} else {
 		// decode destination IP/mask
-		err := ipfRule.decodeIpFilterAddrv4(false, pfcTags[6])
-		if err != nil {
-			logger.QosLog.Errorf("error decoding destination IP/mask: %s", err)
-		}
+		ipfRule.decodeIpFilterAddrv4(false, pfcTags[6])
 
 		// decode destination port/port-range(optional), if any
 		if len(pfcTags) == 8 {
-			err := ipfRule.decodeIpFilterPortInfo(false, pfcTags[7])
-			if err != nil {
-				logger.QosLog.Errorf("error decoding destination port/port-range: %s", err)
-			}
+			ipfRule.decodeIpFilterPortInfo(false, pfcTags[7])
 		}
 	}
 
@@ -309,7 +291,7 @@ func (ipf *IPFilterRule) IsMatchAllIPFilter() bool {
 	return false
 }
 
-func (ipfRule *IPFilterRule) decodeIpFilterPortInfo(source bool, tag string) error {
+func (ipfRule *IPFilterRule) decodeIpFilterPortInfo(source bool, tag string) {
 	// check if it is single port or range
 	ports := strings.Split(tag, "-")
 
@@ -328,10 +310,9 @@ func (ipfRule *IPFilterRule) decodeIpFilterPortInfo(source bool, tag string) err
 			ipfRule.dPort = ports[0]
 		}
 	}
-	return nil
 }
 
-func (ipfRule *IPFilterRule) decodeIpFilterAddrv4(source bool, tag string) error {
+func (ipfRule *IPFilterRule) decodeIpFilterAddrv4(source bool, tag string) {
 	ipAndMask := strings.Split(tag, "/")
 	if source {
 		ipfRule.sAddrv4.addr = ipAndMask[0] // can be x.x.x.x or "any"
@@ -347,7 +328,6 @@ func (ipfRule *IPFilterRule) decodeIpFilterAddrv4(source bool, tag string) error
 			ipfRule.dAddrv4.mask = ipAndMask[1]
 		}
 	}
-	return nil
 }
 
 func (pf *PacketFilter) GetPfContent(flowDesc string) {


### PR DESCRIPTION
# Description

Here we enable the following linters:
- `unparam`
- `noctx`
- `nakedret`

And we make the necessary code changes to have the checks pass.