### PR TITLE
fix: removing NRF cache data after checking notification event type

### DIFF
--- a/consumer/nnrf.go
+++ b/consumer/nnrf.go
@@ -231,7 +231,7 @@ func SendNrfForNfInstance(nrfUri string, targetNfType, requestNfType models.NfTy
 	for _, nfProfile := range result.NfInstances {
 		if _, ok := smfSelf.NfStatusSubscriptions.Load(nfProfile.NfInstanceId); !ok {
 			nrfSubscriptionData := models.NrfSubscriptionData{
-				NfStatusNotificationUri: fmt.Sprintf("%s://%s:%d/nsmf-callback/nf-status-notify",
+				NfStatusNotificationUri: fmt.Sprintf("%s://%s:%d/nsmf-callback/v1/nf-status-notify",
 					smfSelf.URIScheme,
 					smfSelf.RegisterIPv4,
 					smfSelf.SBIPort),

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -24,6 +24,7 @@ var (
 	ConsumerLog *zap.SugaredLogger
 	GinLog      *zap.SugaredLogger
 	GrpcLog     *zap.SugaredLogger
+	ProducerLog *zap.SugaredLogger
 	UPNodeLog   *zap.SugaredLogger
 	FsmLog      *zap.SugaredLogger
 	TxnFsmLog   *zap.SugaredLogger
@@ -69,6 +70,7 @@ func init() {
 	ConsumerLog = log.Sugar().With("component", "SMF", "category", "Consumer")
 	GinLog = log.Sugar().With("component", "SMF", "category", "GIN")
 	GrpcLog = log.Sugar().With("component", "SMF", "category", "GRPC")
+	ProducerLog = log.Sugar().With("component", "SMF", "category", "Producer")
 	UPNodeLog = log.Sugar().With("component", "SMF", "category", "UPNode")
 	FsmLog = log.Sugar().With("component", "SMF", "category", "Fsm")
 	TxnFsmLog = log.Sugar().With("component", "SMF", "category", "TxnFsm")

--- a/pdusession/api_individual_sm_context.go
+++ b/pdusession/api_individual_sm_context.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	mi "github.com/omec-project/util/metricinfo"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	smf_context "github.com/omec-project/smf/context"
@@ -28,6 +27,7 @@ import (
 	"github.com/omec-project/smf/msgtypes/svcmsgtypes"
 	"github.com/omec-project/smf/transaction"
 	"github.com/omec-project/util/httpwrapper"
+	mi "github.com/omec-project/util/metricinfo"
 )
 
 // HTTPReleaseSmContext - Release SM Context

--- a/pdusession/api_sm_contexts_collection.go
+++ b/pdusession/api_sm_contexts_collection.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
-	mi "github.com/omec-project/util/metricinfo"
 	"github.com/omec-project/openapi"
 	"github.com/omec-project/openapi/models"
 	smf_context "github.com/omec-project/smf/context"
@@ -28,6 +27,7 @@ import (
 	"github.com/omec-project/smf/msgtypes/svcmsgtypes"
 	"github.com/omec-project/smf/transaction"
 	"github.com/omec-project/util/httpwrapper"
+	mi "github.com/omec-project/util/metricinfo"
 )
 
 // HTTPPostSmContexts - Create SM Context

--- a/producer/subscription_test.go
+++ b/producer/subscription_test.go
@@ -1,3 +1,7 @@
+// Copyright 2024 Canonical Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package producer
 
 import (

--- a/producer/subscription_test.go
+++ b/producer/subscription_test.go
@@ -1,0 +1,185 @@
+package producer
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/omec-project/openapi/models"
+	smfContext "github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/factory"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	nfInstanceID   = "34343-4343-43-434-343"
+	subscriptionID = "46326-232353-2323"
+)
+
+func setupTest() {
+	if err := factory.InitConfigFactory("../config/smfcfg.yaml"); err != nil {
+		fmt.Printf("Could not InitConfigFactory: %+v", err)
+	}
+}
+
+func TestNfSubscriptionStatusNotify(t *testing.T) {
+	t.Logf("test cases fore NfSubscriptionStatusNotify")
+	callCountSendRemoveSubscription := 0
+	callCountNRFCacheRemoveNfProfileFromNrfCache := 0
+	origSendRemoveSubscription := SendRemoveSubscription
+	origNRFCacheRemoveNfProfileFromNrfCache := NRFCacheRemoveNfProfileFromNrfCache
+	defer func() {
+		SendRemoveSubscription = origSendRemoveSubscription
+		NRFCacheRemoveNfProfileFromNrfCache = origNRFCacheRemoveNfProfileFromNrfCache
+	}()
+	SendRemoveSubscription = func(subscriptionId string) (problemDetails *models.ProblemDetails, err error) {
+		t.Logf("test SendRemoveSubscription called")
+		callCountSendRemoveSubscription++
+		return nil, nil
+	}
+	NRFCacheRemoveNfProfileFromNrfCache = func(nfInstanceId string) bool {
+		t.Logf("test NRFCacheRemoveNfProfileFromNrfCache called")
+		callCountNRFCacheRemoveNfProfileFromNrfCache++
+		return true
+	}
+	udmProfile := models.NfProfileNotificationData{
+		UdrInfo: &models.UdrInfo{
+			SupportedDataSets: []models.DataSetId{
+				models.DataSetId_SUBSCRIPTION,
+			},
+		},
+		NfInstanceId: nfInstanceID,
+		NfType:       "UDM",
+		NfStatus:     "DEREGISTERED",
+	}
+	badRequestProblem := models.ProblemDetails{
+		Status: http.StatusBadRequest,
+		Cause:  "MANDATORY_IE_MISSING",
+		Detail: "Missing IE [Event]/[NfInstanceUri] in NotificationData",
+	}
+	parameters := []struct {
+		expectedProblem                                      *models.ProblemDetails
+		testName                                             string
+		result                                               string
+		nfInstanceId                                         string
+		nfInstanceIdForSubscription                          string
+		subscriptionID                                       string
+		notificationEventType                                string
+		expectedCallCountSendRemoveSubscription              int
+		expectedCallCountNRFCacheRemoveNfProfileFromNrfCache int
+		enableNrfCaching                                     bool
+	}{
+		{
+			nil,
+			"Notification event type DEREGISTERED NRF caching is enabled",
+			"NF profile removed from cache and subscription is removed",
+			nfInstanceID,
+			nfInstanceID,
+			subscriptionID,
+			"NF_DEREGISTERED",
+			1,
+			1,
+			true,
+		},
+		{
+			nil,
+			"Notification event type DEREGISTERED NRF caching is enabled Subscription is not found",
+			"NF profile removed from cache and subscription is not removed",
+			nfInstanceID,
+			"",
+			"",
+			"NF_DEREGISTERED",
+			0,
+			1,
+			true,
+		},
+		{
+			nil,
+			"Notification event type DEREGISTERED NRF caching is disabled",
+			"NF profile is not removed from cache and subscription is removed",
+			nfInstanceID,
+			nfInstanceID,
+			subscriptionID,
+			"NF_DEREGISTERED",
+			1,
+			0,
+			false,
+		},
+		{
+			nil,
+			"Notification event type REGISTERED NRF caching is enabled",
+			"NF profile is not removed from cache and subscription is not removed",
+			nfInstanceID,
+			nfInstanceID,
+			subscriptionID,
+			"NF_REGISTERED",
+			0,
+			0,
+			true,
+		},
+		{
+			nil,
+			"Notification event type DEREGISTERED NRF caching is enabled NfInstanceUri in notificationData is different",
+			"NF profile removed from cache and subscription is not removed",
+			nfInstanceID,
+			nfInstanceID,
+			subscriptionID,
+			"NF_DEREGISTERED",
+			1,
+			1,
+			true,
+		},
+		{
+			&badRequestProblem,
+			"Notification event type DEREGISTERED NRF caching is enabled NfInstanceUri in notificationData is empty",
+			"Return StatusBadRequest with cause MANDATORY_IE_MISSING",
+			"",
+			"",
+			subscriptionID,
+			"NF_DEREGISTERED",
+			0,
+			0,
+			true,
+		},
+		{
+			&badRequestProblem,
+			"Notification event type empty NRF caching is enabled",
+			"Return StatusBadRequest with cause MANDATORY_IE_MISSING",
+			nfInstanceID,
+			nfInstanceID,
+			subscriptionID,
+			"",
+			0,
+			0,
+			true,
+		},
+	}
+	for i := range parameters {
+		t.Run(fmt.Sprintf("NfSubscriptionStatusNotify testname %v result %v", parameters[i].testName, parameters[i].result), func(t *testing.T) {
+			smfContext.SMF_Self().EnableNrfCaching = parameters[i].enableNrfCaching
+			smfContext.SMF_Self().NfStatusSubscriptions.Store(parameters[i].nfInstanceIdForSubscription, parameters[i].subscriptionID)
+			notificationData := models.NotificationData{
+				Event:          models.NotificationEventType(parameters[i].notificationEventType),
+				NfInstanceUri:  parameters[i].nfInstanceId,
+				NfProfile:      &udmProfile,
+				ProfileChanges: []models.ChangeItem{},
+			}
+			err := NfSubscriptionStatusNotifyProcedure(notificationData)
+			assert.Equal(t, parameters[i].expectedProblem, err, "NfSubscriptionStatusNotifyProcedure is failed.")
+			// Subscription is removed.
+			assert.Equal(t, parameters[i].expectedCallCountSendRemoveSubscription, callCountSendRemoveSubscription, "Subscription is not removed.")
+			// NF Profile is removed from NRF cache.
+			assert.Equal(t, parameters[i].expectedCallCountNRFCacheRemoveNfProfileFromNrfCache, callCountNRFCacheRemoveNfProfileFromNrfCache, "NF Profile is not removed from NRF cache.")
+			callCountSendRemoveSubscription = 0
+			callCountNRFCacheRemoveNfProfileFromNrfCache = 0
+			smfContext.SMF_Self().NfStatusSubscriptions.Delete(parameters[i].nfInstanceIdForSubscription)
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	setupTest()
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}


### PR DESCRIPTION
This PR solves the following issues by adding vesion to SMF notification URI and only removing the NRF cache data if notification type is deregistration.
Fixes https://github.com/omec-project/smf/issues/315.
 

1. NfStatusNotificationUri did not include version, however remaining NF's uses v1. 
2. func NfSubscriptionStatusNotifyProcedure removes the NRF cache data when a notification event is received. 

The remaining NF's checks the notification event type and unless it is a "DEREGISTRATION" event, they do not remove the NRF cache. However SMF removes the NRF cache for any notification. 