### PR TITLE
Invalid PDU Session ID in N2 SM Message

### DIFF
--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -222,3 +222,19 @@ func BuildGSMPDUSessionReleaseReject(smContext *SMContext) ([]byte, error) {
 
 	return m.PlainNasEncode()
 }
+
+func BuildGSMPDUSessionReleaseRejectWithCause(smContext *SMContext, pduSessionID int32, cause string) ([]byte, error) {
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionReleaseReject)
+	m.GsmHeader.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	m.PDUSessionReleaseReject = nasMessage.NewPDUSessionReleaseReject(0x0)
+	pDUSessionReleaseRejectWithCause := m.PDUSessionReleaseReject
+	pDUSessionReleaseRejectWithCause.SetMessageType(nas.MsgTypePDUSessionReleaseReject)
+	pDUSessionReleaseRejectWithCause.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	pDUSessionReleaseRejectWithCause.SetPDUSessionID(uint8(pduSessionID))
+	pDUSessionReleaseRejectWithCause.SetPTI(smContext.Pti)
+	uint8Cause := errors.ErrorCause[cause]
+	pDUSessionReleaseRejectWithCause.SetCauseValue(uint8Cause)
+	return m.PlainNasEncode()
+}

--- a/context/gsm_build.go
+++ b/context/gsm_build.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/nas/nasType"
 	"github.com/omec-project/smf/qos"
+	errors "github.com/omec-project/smf/smferrors"
 )
 
 func BuildGSMPDUSessionEstablishmentAccept(smContext *SMContext) ([]byte, error) {

--- a/smferrors/errors.go
+++ b/smferrors/errors.go
@@ -141,4 +141,5 @@ var ErrorCause = map[string]uint8{
 	"ApplySMPolicyFailure":          nasMessage.Cause5GSMRequestRejectedUnspecified,
 	"AMFDiscoveryFailure":           nasMessage.Cause5GSMRequestRejectedUnspecified,
 	"PDUSessionTypeIPv4OnlyAllowed": nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed,
+	"InvalidPDUSessionIdentity":     nasMessage.Cause5GSMInvalidPDUSessionIdentity,
 }


### PR DESCRIPTION
Issue:
If the PDU Session ID to be released which is included in the N2-SM message is invalid, the network should send a PDU Session Release Reject, but it is not being send in the current mainline.

Fix:
Updated the code to validate PDU Session IDs and reject PDU session release requests with invalid IDs.


Supporting Data:
[Invalid-PDUSessionID-N2SM.zip](https://github.com/user-attachments/files/18881450/Invalid-PDUSessionID-N2SM.zip)
