### PR TITLE
feat: use shared workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Intel Corporation
-
+# Copyright 2025 Canonical Ltd.
 version: 2
 updates:
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "21:00"
-      timezone: "America/Los_Angeles"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Canonical Ltd.
 # Copyright 2024 Intel Corporation
-name: Main workflow
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 Canonical Ltd.
 # Copyright 2024 Intel Corporation
-
 name: Main workflow
 
 on:
@@ -14,82 +13,42 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Build
-        run: go build
+    uses: omec-project/.github/.github/workflows/build.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   docker-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: omec-project/.github/.github/workflows/docker-build.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
-      - name: Build Docker image
-        run: make docker-build
+  static-analysis:
+    uses: omec-project/.github/.github/workflows/static-analysis.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7.0.0
-        with:
-          version: latest
-          args: -v --timeout=5m  --config ./.golangci.yml
+    uses: omec-project/.github/.github/workflows/lint.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   hadolint:
-    name: hadolint
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Dockerfile linter
-        uses: hadolint/hadolint-action@v3.1.0
-        # For now, ignoring:
-        # DL3008 warning: Pin versions in apt get install (e.g., apt-get install <package>=<version>); and
-        # DL3018 warning: Pin versions in apk add (e.g., apk add <package>=<version>)
-        with:
-          dockerfile: Dockerfile
-          ignore: DL3008,DL3018
+    uses: omec-project/.github/.github/workflows/hadolint.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   license-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: omec-project/.github/.github/workflows/license-check.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
-      - name: reuse lint
-        uses: fsfe/reuse-action@v5
-
-  fossa-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: FOSSA scan
-        uses: fossa-contrib/fossa-action@v3
-        with:
-          fossa-api-key: 0c3bbcdf20e157bbd487dae173751b28
+  fossa-scan:
+    uses: omec-project/.github/.github/workflows/fossa-scan.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
   unit-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: omec-project/.github/.github/workflows/unit-test.yml@main
+    with:
+      branch_name: ${{ github.ref }}
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Unit tests
-        run: go test ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
     with:
       branch_name: ${{ github.ref }}
 
-  static-analysis:
-    uses: omec-project/.github/.github/workflows/static-analysis.yml@main
-    with:
-      branch_name: ${{ github.ref }}
+  #static-analysis:
+  #  uses: omec-project/.github/.github/workflows/static-analysis.yml@main
+  #  with:
+  #    branch_name: ${{ github.ref }}
 
   lint:
     uses: omec-project/.github/.github/workflows/lint.yml@main

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Intel Corporation
 # Copyright 2025 Canonical Ltd.
-name: GitHub release and Docker images
-
 on:
   push:
+    branches:
+      - main
     tags:
       - v*
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,192 +1,31 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Intel Corporation
+# Copyright 2025 Canonical Ltd.
 name: GitHub release and Docker images
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
 
 jobs:
-  push-images:
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'omec-project'
-    env:
-      REGISTRY: registry.aetherproject.org
-      DOCKER_REGISTRY: registry.aetherproject.org/
-      DOCKER_REPOSITORY: sdcore/
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - run: echo GIT_SHA_SHORT=$(git rev-parse --short HEAD) >> $GITHUB_ENV
-
-      - uses: docker/login-action@v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.AETHER_REGISTRY_USERNAME }}
-          password: ${{ secrets.AETHER_REGISTRY_PASSWORD }}
-
-      - name: Build and push "main-latest" Docker image
-        env:
-          DOCKER_TAG: main-latest
-        run: |
-          make docker-build
-          make docker-push
-
-      - name: Build and push "main-GIT_SHA" Docker image
-        env:
-          DOCKER_TAG: main-${{ env.GIT_SHA_SHORT }}
-        run: |
-          make docker-build
-          make docker-push
-
-  # CAUTION: Other actions depend on this name "tag-github"
   tag-github:
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'omec-project'
-    outputs:
-      changed: ${{ steps.version-change.outputs.changed }}
-      version: ${{ steps.version-change.outputs.version }}
-      release_branch: ${{ steps.version-change.outputs.release_branch }}
-      version_branch: ${{ steps.version-change.outputs.version_branch }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changes
-        id: version-file
-        run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep VERSION; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            version_before=$(git show ${{ github.event.before }}:VERSION)
-            echo "version_before=$version_before" >> $GITHUB_OUTPUT
-          else
-            echo "VERSION file was not changed"
-          fi
-
-      - name: Validate change in version file
-        id: version-change
-        if: steps.version-file.outputs.changed == 'true'
-        run: |
-          version=$(cat VERSION)
-          version_before_full=${{ steps.version-file.outputs.version_before }}
-          version_before=${version_before_full::-4}
-          echo "version=$version"
-          echo "version_before=$version_before"
-          validate="^[0-9]+\.[0-9]+\.[0-9]+$"
-          if [[ $version =~ $validate ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "version=$version" >> $GITHUB_OUTPUT
-          else
-            echo "Version change not for release"
-          fi
-          if [[ $version_before =~ $validate ]]; then
-            IFS='.' read -r major minor patch <<< "$version"
-            IFS='.' read -r major_b minor_b patch_b <<< "$version_before"
-            if [[ "$major" -ne "$major_b" ]] || [[ "$minor" -ne "$minor_b" ]]; then
-              version_branch="$major_b.$minor_b"
-              echo "release_branch=true" >> $GITHUB_OUTPUT
-              echo "version_branch=$version_branch" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "Version change not for branch release"
-          fi
-
-      - name: Create release using REST API
-        if: steps.version-change.outputs.changed == 'true'
-        run: |
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GH_OMEC_PAT }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/releases \
-            -d '{
-              "tag_name": "v${{ steps.version-change.outputs.version }}",
-              "target_commitish": "${{ github.event.repository.default_branch }}",
-              "name": "v${{ steps.version-change.outputs.version }}",
-              "draft": false,
-              "prerelease": false,
-              "generate_release_notes": true
-              }'
+    uses: omec-project/.github/.github/workflows/tag-github.yml@main
 
   release-image:
-    runs-on: ubuntu-latest
     needs: tag-github
-    if: needs.tag-github.outputs.changed == 'true'
-    env:
-      REGISTRY: docker.io
-      DOCKER_REGISTRY: docker.io/
-      DOCKER_REPOSITORY: omecproject/
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-
-      - uses: docker/login-action@v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and push release Docker image
-        env:
-          DOCKER_TAG: rel-${{ needs.tag-github.outputs.version }}
-        run: |
-          make docker-build
-          make docker-push
+    uses: omec-project/.github/.github/workflows/release-image.yml@main
+    with:
+      branch_name: ${{ github.ref }}
+    secrets: inherit
 
   update-version:
-    runs-on: ubuntu-latest
     needs: tag-github
-    if: needs.tag-github.outputs.changed == 'true'
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Increment version
-        run: |
-          version=${{ needs.tag-github.outputs.version }}
-          IFS='.' read -r major minor patch <<< "$version"
-          patch_update=$((patch+1))
-          NEW_VERSION="$major.$minor.$patch_update-dev"
-          echo $NEW_VERSION > VERSION
-          echo "Updated version: $NEW_VERSION"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GH_OMEC_PAT }}
-          commit-message: Update version
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          signoff: true
-          branch: version-update
-          delete-branch: true
-          title: Update version
-          body: |
-            Update VERSION file
-          add-paths: |
-            VERSION
+    uses: omec-project/.github/.github/workflows/update-version.yml@main
+    secrets: inherit
 
   branch-release:
-    runs-on: ubuntu-latest
     needs: tag-github
-    if: (needs.tag-github.outputs.changed == 'true') && (needs.tag-github.outputs.release_branch == 'true')
-    env:
-      GITHUB_TOKEN: ${{ secrets.GH_OMEC_PAT }}
-    steps:
-      - uses: actions/checkout@v4
+    uses: omec-project/.github/.github/workflows/update-version.yml@main
+    secrets: inherit
 
-      - uses: peterjgrainger/action-create-branch@v3.0.0
-        with:
-          branch: "rel-${{ needs.tag-github.outputs.version_branch }}"
-          sha: '${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,25 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Intel Corporation
+# Copyright 2025 Canonical Ltd.
 name: Stale issue/pr
 
 on:
   schedule:
-  - cron: "0 0 * * *"
-
-env:
-  DAYS_BEFORE_STALE: 120
-  DAYS_BEFORE_CLOSE: 15
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/stale@v9
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has been stale for ${{ env.DAYS_BEFORE_STALE }} days and will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days. Comment to keep it open.'
-        stale-pr-message: 'This pull request has been stale for ${{ env.DAYS_BEFORE_STALE }} days and will be closed in ${{ env.DAYS_BEFORE_CLOSE }} days. Comment to keep it open.'
-        stale-issue-label: 'stale/issue'
-        stale-pr-label: 'stale/pr'
-        days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
-        days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+    uses: omec-project/.github/.github/workflows/stale-issue.yml@main
+    with:
+      days_before_stale: 120
+      days_before_close: 15
+    secrets: inherit
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,4 +12,3 @@ jobs:
       days_before_stale: 120
       days_before_close: 15
     secrets: inherit
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 Intel Corporation
 # Copyright 2025 Canonical Ltd.
-name: Stale issue/pr
-
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
All the workflows which are used in the repositories of omec-project is stored in a single repository called .github. 
This PR uses the shared workflows from .github repository.
The existing linting job sets 5m timeout but it seems this timeout is not necessary.
The static-check workflow is not added now as it fails.