### PR TITLE
chore: bump openapi to 1.6.0

### DIFF
--- a/consumer/nnrf.go
+++ b/consumer/nnrf.go
@@ -185,7 +185,7 @@ func getSvcMsgType(nfType models.NfType) svcmsgtypes.SmfMsgType {
 	return svcMsgType
 }
 
-func SendNrfForNfInstance(nrfUri string, targetNfType, requestNfType models.NfType,
+func SendNrfForNfInstance(ctx context.Context, nrfUri string, targetNfType, requestNfType models.NfType,
 	param *Nnrf_NFDiscovery.SearchNFInstancesParamOpts,
 ) (models.SearchResult, error) {
 	result, httpResp, localErr := smf_context.SMF_Self().
@@ -257,10 +257,12 @@ func SendNFDiscoveryUDM() (*models.ProblemDetails, error) {
 	var result models.SearchResult
 	var localErr error
 
+	ctx := context.Background()
+
 	if smf_context.SMF_Self().EnableNrfCaching {
-		result, localErr = nrfCache.SearchNFInstances(smf_context.SMF_Self().NrfUri, models.NfType_UDM, models.NfType_SMF, &localVarOptionals)
+		result, localErr = nrfCache.SearchNFInstances(ctx, smf_context.SMF_Self().NrfUri, models.NfType_UDM, models.NfType_SMF, &localVarOptionals)
 	} else {
-		result, localErr = SendNrfForNfInstance(smf_context.SMF_Self().NrfUri, models.NfType_UDM, models.NfType_SMF, &localVarOptionals)
+		result, localErr = SendNrfForNfInstance(ctx, smf_context.SMF_Self().NrfUri, models.NfType_UDM, models.NfType_SMF, &localVarOptionals)
 	}
 
 	if localErr == nil {
@@ -295,10 +297,12 @@ func SendNFDiscoveryPCF() (problemDetails *models.ProblemDetails, err error) {
 	var result models.SearchResult
 	var localErr error
 
+	ctx := context.Background()
+
 	if smf_context.SMF_Self().EnableNrfCaching {
-		result, localErr = nrfCache.SearchNFInstances(smf_context.SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
+		result, localErr = nrfCache.SearchNFInstances(ctx, smf_context.SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
 	} else {
-		result, localErr = SendNrfForNfInstance(smf_context.SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
+		result, localErr = SendNrfForNfInstance(ctx, smf_context.SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
 	}
 
 	if localErr == nil {
@@ -325,9 +329,9 @@ func SendNFDiscoveryServingAMF(smContext *smf_context.SMContext) (*models.Proble
 	var localErr error
 
 	if smf_context.SMF_Self().EnableNrfCaching {
-		result, localErr = nrfCache.SearchNFInstances(smf_context.SMF_Self().NrfUri, models.NfType_AMF, models.NfType_SMF, &localVarOptionals)
+		result, localErr = nrfCache.SearchNFInstances(context.Background(), smf_context.SMF_Self().NrfUri, models.NfType_AMF, models.NfType_SMF, &localVarOptionals)
 	} else {
-		result, localErr = SendNrfForNfInstance(smf_context.SMF_Self().NrfUri, models.NfType_AMF, models.NfType_SMF, &localVarOptionals)
+		result, localErr = SendNrfForNfInstance(context.Background(), smf_context.SMF_Self().NrfUri, models.NfType_AMF, models.NfType_SMF, &localVarOptionals)
 	}
 
 	if localErr == nil {

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -395,7 +395,7 @@ func (smContext *SMContext) PCFSelection() error {
 	var err error
 
 	if SMF_Self().EnableNrfCaching {
-		rep, err = nrfCache.SearchNFInstances(SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
+		rep, err = nrfCache.SearchNFInstances(context.Background(), SMF_Self().NrfUri, models.NfType_PCF, models.NfType_SMF, &localVarOptionals)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/omec-project/config5g v1.6.2
 	github.com/omec-project/nas v1.5.3
 	github.com/omec-project/ngap v1.4.2
-	github.com/omec-project/openapi v1.5.0
+	github.com/omec-project/openapi v1.6.0
 	github.com/omec-project/util v1.3.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/omec-project/nas v1.5.3 h1:xX/Mdc1DQWxxN82NCexPGlxaaPleQp1bnmN4uTmIVM
 github.com/omec-project/nas v1.5.3/go.mod h1:am1sKsRpNblkjGbM6I2dtdjFooYqqeL1ZgV4HSd+wUo=
 github.com/omec-project/ngap v1.4.2 h1:1p4tozYxmgD+fqBT+i4DAL0GNd0+/rFgpUKxcxKoyYw=
 github.com/omec-project/ngap v1.4.2/go.mod h1:xYB2+a2t1dAq6F2YTDUGHLuhWESBbOJQ3L1OJvcL0b8=
-github.com/omec-project/openapi v1.5.0 h1:WV3JjYwqio1xRTb1Nvc6kpSGgf+/VzrScU9WS9PBNwE=
-github.com/omec-project/openapi v1.5.0/go.mod h1:4nwAVKA4GUXw5OnjxYOU8LAoRrpGTG/ruJLgKiE/Ccs=
+github.com/omec-project/openapi v1.6.0 h1:ZGjIVt/Yy6wxI88/H9XMt5a84evjVf0H68b/tl5lOPA=
+github.com/omec-project/openapi v1.6.0/go.mod h1:4nwAVKA4GUXw5OnjxYOU8LAoRrpGTG/ruJLgKiE/Ccs=
 github.com/omec-project/util v1.3.2 h1:5JP4ZYqMPPESSYrgc6LQNlcvJ/Xhrq8u5jSV405iuX8=
 github.com/omec-project/util v1.3.2/go.mod h1:Q5hNzZ0VSIbYzi+FRaJrvVD12BxK0n5uoNvvV3qn+ro=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=


### PR DESCRIPTION
## Overview

Bump openapi to v1.6.0 and make necessary related changes.