### PR TITLE
fix: test flakiness

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -41,9 +41,13 @@ func getNfProfile(smfCtx *smfContext.SMFContext, sessionCfgs []nfConfigApi.Sessi
 	snssais := buildSNssais(sessionCfgs)
 	plmnList := buildPlmnList(sessionCfgs)
 	smfInfo := buildSmfInfo(sessionCfgs)
+	serviceNames := []string{"nsmf-pdusession"}
+	if factory.SmfConfig.Configuration != nil && len(factory.SmfConfig.Configuration.ServiceNameList) > 0 {
+		serviceNames = factory.SmfConfig.Configuration.ServiceNameList
+	}
 	now := time.Now()
-	nfServices := make([]models.NfService, 0)
-	for _, serviceName := range factory.SmfConfig.Configuration.ServiceNameList {
+	nfServices := make([]models.NfService, 0, len(serviceNames))
+	for _, serviceName := range serviceNames {
 		nfServices = append(nfServices, models.NfService{
 			ServiceInstanceId: smfCtx.NfInstanceID + "-" + serviceName,
 			ServiceName:       models.ServiceName(serviceName),


### PR DESCRIPTION
This PR aims to fix following errors:

1. Flakiness in nf registration test:  https://github.com/omec-project/smf/actions/runs/16949804615/job/48039743300 which came from dereferencing a nil Configuration due to shared, uninitialized global state and races. Hence, nil checks are added for global factory.SmfConfig.Configuration and test is improved to be more deterministic. The  old test incremented called from a goroutine and then read it in the main goroutine caused data race.
We improved the unit test  by no longer using sleep for 2 * retryTime instead we wait for two real attempts with a bounded timeout. This removes flakiness caused by clock/scheduler variance.

2. Flakiness in  UDP tests: https://github.com/omec-project/smf/actions/runs/16989607132/job/48165703488. The panic comes from TestServerNotSetSendPfcp setting udp.Server = nil while the reader goroutine started by TestRun is still running. The goroutine checks Server != nil, then soon after dereferences Server.Conn.ReadFromUDP. If another test sets udp.Server = nil between those two steps, we get the nil-pointer at udp.go:140. Now, we are closing the connection instead of continuing indefinitely, so it won’t keep touching udp.Server after the test ends. Besides, we don’t mutate the global to nil while a server may be alive in other tests.
