### PR TITLE
fix: retry N1N2MessageTransfer with AMF re-discovery on stale endpoint

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -397,6 +397,115 @@ func SendNFDiscoveryServingAMF(smContext *smfContext.SMContext) (*models.Problem
 	return nil, nil
 }
 
+// n1n2TransferTimeout is the HTTP timeout for a single N1N2MessageTransfer attempt.
+// Kept short so that retries with AMF re-discovery can happen within the UE's T3580 window.
+const n1n2TransferTimeout = 5 * time.Second
+
+// SendN1N2TransferWithRediscovery sends an N1N2MessageTransfer request using the
+// SMContext's CommunicationClient. If the request fails (including timeout), it
+// queries NRF directly (bypassing the cache) and tries every other AMF candidate
+// until one succeeds. This handles the case where NRF has multiple stale
+// registrations left behind by prior AMF pod restarts.
+func SendN1N2TransferWithRediscovery(ctx context.Context, smContext *smfContext.SMContext,
+	n1n2Request models.N1N2MessageTransferRequest,
+) (models.N1N2MessageTransferRspData, error) {
+	if smContext.CommunicationClient == nil {
+		// Client was never built (e.g. recovered from DB with stale AMFProfile).
+		// Use the first candidate from NRF to seed it; if it fails, the retry loop below takes over.
+		if err := selectFirstAmfFromNrf(smContext); err != nil {
+			return models.N1N2MessageTransferRspData{}, fmt.Errorf("AMF discovery failed: %w", err)
+		}
+	}
+
+	// First attempt with the currently-selected AMF
+	rspData, err := tryN1N2Transfer(ctx, smContext, n1n2Request)
+	if err == nil {
+		return rspData, nil
+	}
+	firstErr := err
+	smContext.SubPduSessLog.Warnf("N1N2Transfer failed (%v), attempting AMF re-discovery", err)
+
+	// First attempt failed — fetch all AMF candidates from NRF (bypassing cache)
+	// and try each one that isn't the NfInstanceId we already failed on.
+	candidates, discErr := fetchAmfCandidates()
+	if discErr != nil {
+		return models.N1N2MessageTransferRspData{}, fmt.Errorf("N1N2Transfer failed (%w) and AMF re-discovery failed: %v", firstErr, discErr)
+	}
+
+	failedNfId := smContext.ServingNfId
+	attempted := 0
+	for _, candidate := range candidates {
+		if candidate.NfInstanceId == failedNfId {
+			continue
+		}
+		if err := useAmfProfile(smContext, candidate); err != nil {
+			smContext.SubPduSessLog.Warnf("AMF candidate %s unusable: %v", candidate.NfInstanceId, err)
+			continue
+		}
+		attempted++
+		smContext.SubPduSessLog.Infof("AMF re-discovery retry %d: trying NfInstanceId %s", attempted, candidate.NfInstanceId)
+		rspData, err = tryN1N2Transfer(ctx, smContext, n1n2Request)
+		if err == nil {
+			smContext.SubPduSessLog.Infof("AMF re-discovery succeeded on attempt %d with NfInstanceId %s", attempted, candidate.NfInstanceId)
+			return rspData, nil
+		}
+		smContext.SubPduSessLog.Warnf("AMF re-discovery retry %d failed: %v", attempted, err)
+	}
+
+	if attempted == 0 {
+		return models.N1N2MessageTransferRspData{}, fmt.Errorf("N1N2Transfer failed (%w) and no alternative AMF candidates available", firstErr)
+	}
+	return models.N1N2MessageTransferRspData{}, fmt.Errorf("N1N2Transfer failed after %d AMF candidates; last error: %w", attempted, err)
+}
+
+// tryN1N2Transfer makes a single N1N2MessageTransfer call with a short timeout.
+func tryN1N2Transfer(ctx context.Context, smContext *smfContext.SMContext,
+	n1n2Request models.N1N2MessageTransferRequest,
+) (models.N1N2MessageTransferRspData, error) {
+	tryCtx, cancel := context.WithTimeout(ctx, n1n2TransferTimeout)
+	defer cancel()
+	rspData, _, err := smContext.CommunicationClient.
+		N1N2MessageCollectionDocumentApi.
+		N1N2MessageTransfer(tryCtx, smContext.Supi, n1n2Request)
+	return rspData, err
+}
+
+// fetchAmfCandidates queries NRF directly (bypassing the cache) for all registered AMFs.
+func fetchAmfCandidates() ([]models.NfProfile, error) {
+	localVarOptionals := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{}
+	ctx := context.Background()
+	result, err := SendNrfForNfInstance(ctx, smfContext.SMF_Self().NrfUri, models.NfType_AMF, models.NfType_SMF, &localVarOptionals)
+	if err != nil {
+		return nil, fmt.Errorf("broad AMF discovery failed: %w", err)
+	}
+	if result.NfInstances == nil || len(result.NfInstances) == 0 {
+		return nil, fmt.Errorf("broad AMF discovery returned no AMF instances")
+	}
+	return result.NfInstances, nil
+}
+
+// useAmfProfile selects the given AMF profile on the SMContext and rebuilds the CommunicationClient.
+func useAmfProfile(smContext *smfContext.SMContext, profile models.NfProfile) error {
+	smContext.AMFProfile = deepcopy.Copy(profile).(models.NfProfile)
+	smContext.ServingNfId = smContext.AMFProfile.NfInstanceId
+	smContext.RebuildCommunicationClient()
+	if smContext.CommunicationClient == nil {
+		return fmt.Errorf("AMF profile %s has no Namf_Communication service", profile.NfInstanceId)
+	}
+	return nil
+}
+
+// selectFirstAmfFromNrf picks the first AMF from a direct NRF query and installs it on the SMContext.
+// Used only to bootstrap a nil CommunicationClient after DB recovery.
+func selectFirstAmfFromNrf(smContext *smfContext.SMContext) error {
+	smContext.SubPduSessLog.Infof("AMF discovery: querying NRF directly (bypassing cache)")
+	candidates, err := fetchAmfCandidates()
+	if err != nil {
+		return err
+	}
+	return useAmfProfile(smContext, candidates[0])
+}
+
 func SendCreateSubscription(nrfUri string, nrfSubscriptionData models.NrfSubscriptionData) (nrfSubData models.NrfSubscriptionData, problemDetails *models.ProblemDetails, err error) {
 	logger.ConsumerLog.Debugln("send Create Subscription")
 

--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -8,6 +8,7 @@ package consumer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -35,6 +36,10 @@ var newNrfNFManagementHTTPClient = func() *http.Client {
 }
 
 const podIPPlaceholder = "POD_IP"
+
+// n1n2TransferTimeout is the HTTP timeout for a single N1N2MessageTransfer attempt.
+// Kept short so that retries with AMF re-discovery can happen within the UE's T3580 window.
+const n1n2TransferTimeout = 5 * time.Second
 
 func normalizeAdvertisedSmfHost(nfProfile *models.NFProfile) {
 	if nfProfile == nil {
@@ -476,6 +481,235 @@ func SendNFDiscoveryServingAMF(smContext *smfContext.SMContext) (*models.Problem
 		return nil, localErr
 	}
 	return nil, nil
+}
+
+// SendN1N2TransferWithRediscovery sends an N1N2MessageTransfer request using the
+// SMContext's CommunicationClient. If the request fails (including timeout), it
+// queries NRF directly (bypassing the cache) and tries every other AMF candidate
+// until one succeeds. This handles the case where NRF has multiple stale
+// registrations left behind by prior AMF pod restarts.
+func SendN1N2TransferWithRediscovery(ctx context.Context, smContext *smfContext.SMContext,
+	n1n2Request *models.N1N2MessageTransferRequest,
+) (*models.N1N2MessageTransferRspData, error) {
+	// Re-discovery mutates AMFProfile/ServingNfId/CommunicationClient while trying
+	// candidates. Snapshot them so a failed or aborted re-discovery leaves the session
+	// pointing at its original serving AMF rather than the last (failed) candidate —
+	// otherwise ServingNfId would be corrupted for later targeted discovery. Restored
+	// unless a transfer succeeds (committed).
+	origProfile := smContext.AMFProfile
+	origServingNfId := smContext.ServingNfId
+	origClient := smContext.CommunicationClient
+	committed := false
+	defer func() {
+		if !committed {
+			smContext.AMFProfile = origProfile
+			smContext.ServingNfId = origServingNfId
+			smContext.CommunicationClient = origClient
+		}
+	}()
+
+	if smContext.CommunicationClient == nil {
+		// Client not built yet (e.g. SMContext recovered from DB). Prefer rebuilding
+		// from the session's existing AMFProfile so we don't needlessly switch AMFs;
+		// only seed from NRF if that still leaves the client nil.
+		smContext.RebuildCommunicationClient()
+		if smContext.CommunicationClient == nil {
+			if err := selectAmfFromNrf(ctx, smContext); err != nil {
+				return nil, fmt.Errorf("AMF discovery failed: %w", err)
+			}
+		}
+	}
+
+	// First attempt with the currently-selected AMF
+	rspData, err := tryN1N2Transfer(ctx, smContext, n1n2Request)
+	if err == nil {
+		committed = true
+		return rspData, nil
+	}
+	// Only re-discover on transport-level failures (no HTTP response). An HTTP error
+	// from a reachable AMF, or a cancelled caller context, must not trigger retries
+	// against other AMFs (would risk duplicate N1/N2 delivery / ignore cancellation).
+	if !shouldRediscoverAMF(ctx, err) {
+		return rspData, err
+	}
+	smContext.SubPduSessLog.Warnf("N1N2Transfer failed (%v), attempting AMF re-discovery", err)
+
+	// First attempt failed — fetch all AMF candidates from NRF (bypassing cache)
+	// and try each, rebuilding the client from fresh NRF data. Candidates with a
+	// different NfInstanceId are tried first (handles the AMF-restarted-with-a-new-
+	// NfInstanceId case, where the failed id is a stale/dead entry); the candidate
+	// with the same NfInstanceId as the one that just failed is tried last, since
+	// its NRF profile may carry an updated ApiPrefix (AMF re-registered in place
+	// with the same id but a new endpoint).
+	candidates, discErr := fetchAmfCandidates(ctx)
+	if discErr != nil {
+		return nil, fmt.Errorf("N1N2Transfer failed and AMF re-discovery failed: %w", errors.Join(err, discErr))
+	}
+
+	attempted := 0
+	for _, candidate := range orderAmfCandidates(candidates, smContext.ServingNfId) {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("N1N2Transfer aborted during AMF re-discovery: %w", ctx.Err())
+		}
+		if useErr := useAmfProfile(smContext, candidate); useErr != nil {
+			smContext.SubPduSessLog.Warnf("AMF candidate %s unusable: %v", candidate.GetNfInstanceId(), useErr)
+			continue
+		}
+		attempted++
+		smContext.SubPduSessLog.Infof("AMF re-discovery retry %d: trying NfInstanceId %s", attempted, candidate.GetNfInstanceId())
+		rspData, err = tryN1N2Transfer(ctx, smContext, n1n2Request)
+		if err == nil {
+			smContext.SubPduSessLog.Infof("AMF re-discovery succeeded on attempt %d with NfInstanceId %s", attempted, candidate.GetNfInstanceId())
+			committed = true
+			return rspData, nil
+		}
+		smContext.SubPduSessLog.Warnf("AMF re-discovery retry %d failed: %v", attempted, err)
+	}
+
+	if attempted == 0 {
+		return nil, fmt.Errorf("N1N2Transfer failed (%w) and no alternative AMF candidates available", err)
+	}
+	return nil, fmt.Errorf("N1N2Transfer failed after %d AMF candidates; last error: %w", attempted, err)
+}
+
+// shouldRediscoverAMF reports whether an N1N2MessageTransfer error warrants AMF
+// re-discovery and retry. Only transport-level failures (connection refused, TLS,
+// or our own per-attempt timeout — i.e. no HTTP response was received) qualify.
+// A cancelled/expired caller context, or an HTTP error returned by a reachable AMF
+// (surfaced as openapi.GenericOpenAPIError), must NOT trigger retries against other
+// AMFs: that would risk duplicate N1/N2 delivery and ignore the caller's intent.
+func shouldRediscoverAMF(ctx context.Context, err error) bool {
+	if ctx.Err() != nil {
+		return false // caller cancelled or deadline exceeded
+	}
+	// The generated client returns *openapi.GenericOpenAPIError; also check the value
+	// form defensively in case a code path returns it by value.
+	var apiErrPtr *openapi.GenericOpenAPIError
+	var apiErrVal openapi.GenericOpenAPIError
+	if errors.As(err, &apiErrPtr) || errors.As(err, &apiErrVal) {
+		return false // the AMF responded with an HTTP error — it is reachable
+	}
+	return true
+}
+
+// tryN1N2Transfer makes a single N1N2MessageTransfer call with a short timeout.
+func tryN1N2Transfer(ctx context.Context, smContext *smfContext.SMContext,
+	n1n2Request *models.N1N2MessageTransferRequest,
+) (*models.N1N2MessageTransferRspData, error) {
+	tryCtx, cancel := context.WithTimeout(ctx, n1n2TransferTimeout)
+	defer cancel()
+	apiReq := smContext.CommunicationClient.
+		N1N2MessageCollectionCollectionAPI.
+		N1N2MessageTransfer(tryCtx, smContext.Supi).
+		N1N2MessageTransferReqData(n1n2Request.GetJsonData())
+	if binaryDataN1Message := n1n2Request.GetBinaryDataN1Message(); binaryDataN1Message != nil {
+		apiReq = apiReq.BinaryDataN1Message(binaryDataN1Message)
+	}
+	if binaryDataN2Information := n1n2Request.GetBinaryDataN2Information(); binaryDataN2Information != nil {
+		apiReq = apiReq.BinaryDataN2Information(binaryDataN2Information)
+	}
+	rspData, _, err := smContext.CommunicationClient.
+		N1N2MessageCollectionCollectionAPI.
+		N1N2MessageTransferExecute(apiReq)
+	return rspData, err
+}
+
+// orderAmfCandidates returns all candidates, preserving NRF order, but moves any
+// candidate whose NfInstanceId equals failedNfId to the end. Every candidate is
+// retried (the per-attempt timeout bounds the cost of dead ones): a different
+// NfInstanceId is the live AMF when it restarted with a new id, and the same
+// NfInstanceId may carry a refreshed ApiPrefix when the AMF re-registered in place.
+func orderAmfCandidates(candidates []models.NFProfileDiscovery, failedNfId string) []models.NFProfileDiscovery {
+	out := make([]models.NFProfileDiscovery, 0, len(candidates))
+	var sameID []models.NFProfileDiscovery
+	for _, c := range candidates {
+		if c.GetNfInstanceId() == failedNfId {
+			sameID = append(sameID, c)
+			continue
+		}
+		out = append(out, c)
+	}
+	return append(out, sameID...)
+}
+
+// searchAmfInstancesNoSubscribe queries NRF directly (cache-bypassing) for AMF instances
+// WITHOUT creating NF-status subscriptions. SendNrfForNfInstance subscribes to every
+// returned instance; for best-effort re-discovery that would subscribe the SMF to every
+// AMF in the deployment (including dead ones), which is an unwanted side effect. If
+// targetNfInstanceId is non-empty the query is targeted at that single AMF.
+func searchAmfInstancesNoSubscribe(ctx context.Context, targetNfInstanceId string) (*models.SearchResult, error) {
+	client := newNrfNFDiscoveryClient(smfContext.SMF_Self().NrfUri)
+	req := client.NFInstancesStoreAPI.SearchNFInstances(ctx).
+		TargetNfType(models.NFTYPE_AMF).
+		RequesterNfType(models.NFTYPE_SMF)
+	if targetNfInstanceId != "" {
+		req = req.TargetNfInstanceId(targetNfInstanceId)
+	}
+	result, httpResp, err := client.NFInstancesStoreAPI.SearchNFInstancesExecute(req)
+	if httpResp != nil && httpResp.Body != nil {
+		defer func() {
+			if cerr := httpResp.Body.Close(); cerr != nil {
+				logger.ConsumerLog.Errorf("SearchNFInstances response body cannot close: %+v", cerr)
+			}
+		}()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// fetchAmfCandidates queries NRF directly (bypassing the cache and without subscribing)
+// for all registered AMFs. It derives its timeout from the caller's ctx so caller
+// cancellation/deadlines are honoured, while still bounding the wait if NRF is slow.
+func fetchAmfCandidates(ctx context.Context) ([]models.NFProfileDiscovery, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, n1n2TransferTimeout)
+	defer cancel()
+	result, err := searchAmfInstancesNoSubscribe(queryCtx, "")
+	if err != nil {
+		return nil, fmt.Errorf("broad AMF discovery failed: %w", err)
+	}
+	if result == nil || len(result.GetNfInstances()) == 0 {
+		return nil, fmt.Errorf("broad AMF discovery returned no AMF instances")
+	}
+	return result.GetNfInstances(), nil
+}
+
+// useAmfProfile selects the given AMF profile on the SMContext and rebuilds the CommunicationClient.
+func useAmfProfile(smContext *smfContext.SMContext, profile models.NFProfileDiscovery) error {
+	smContext.AMFProfile = deepcopy.Copy(profile).(models.NFProfileDiscovery)
+	smContext.ServingNfId = smContext.AMFProfile.GetNfInstanceId()
+	smContext.RebuildCommunicationClient()
+	if smContext.CommunicationClient == nil {
+		return fmt.Errorf("AMF profile %s has no Namf_Communication service", profile.GetNfInstanceId())
+	}
+	return nil
+}
+
+// selectAmfFromNrf installs an AMF on the SMContext via a direct (cache-bypassing) NRF
+// query, used to bootstrap a nil CommunicationClient. It prefers a targeted lookup by the
+// session's ServingNfId (the AMF that actually serves this UE), so we don't silently switch
+// the session to an unrelated AMF; it falls back to the first broad candidate only if
+// ServingNfId is unset or the targeted lookup yields nothing.
+func selectAmfFromNrf(ctx context.Context, smContext *smfContext.SMContext) error {
+	if servingNfId := smContext.ServingNfId; servingNfId != "" {
+		smContext.SubPduSessLog.Infof("AMF discovery: targeted NRF lookup for ServingNfId %s (bypassing cache)", servingNfId)
+		queryCtx, cancel := context.WithTimeout(ctx, n1n2TransferTimeout)
+		result, err := searchAmfInstancesNoSubscribe(queryCtx, servingNfId)
+		cancel()
+		if err == nil && result != nil && len(result.GetNfInstances()) > 0 {
+			return useAmfProfile(smContext, result.GetNfInstances()[0])
+		}
+		smContext.SubPduSessLog.Warnf("targeted AMF lookup for ServingNfId %s found nothing, falling back to broad discovery", servingNfId)
+	} else {
+		smContext.SubPduSessLog.Infof("AMF discovery: no ServingNfId, broad NRF lookup (bypassing cache)")
+	}
+
+	candidates, err := fetchAmfCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	return useAmfProfile(smContext, candidates[0])
 }
 
 func SendCreateSubscription(nrfUri string, nrfSubscriptionData models.SubscriptionData) (nrfSubData *models.SubscriptionData, problemDetails *models.ProblemDetails, err error) {

--- a/consumer/nf_management_amf_rediscover_test.go
+++ b/consumer/nf_management_amf_rediscover_test.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Forsway Solutions AB
+// SPDX-License-Identifier: Apache-2.0
+
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/omec-project/openapi/v2"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+// ② re-discovery must fire only on transport-level failures, not on an HTTP error
+// from a reachable AMF, and not when the caller context is already done.
+func TestShouldRediscoverAMF(t *testing.T) {
+	t.Run("transport error -> retry", func(t *testing.T) {
+		if !shouldRediscoverAMF(context.Background(), errors.New("dial tcp 10.0.0.1:29518: i/o timeout")) {
+			t.Error("expected re-discovery on a transport error")
+		}
+	})
+	t.Run("cancelled context -> no retry", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if shouldRediscoverAMF(ctx, errors.New("any error")) {
+			t.Error("expected no re-discovery when caller context is cancelled")
+		}
+	})
+	t.Run("HTTP error from AMF (pointer, as the client returns it) -> no retry", func(t *testing.T) {
+		var apiErr error = &openapi.GenericOpenAPIError{}
+		if shouldRediscoverAMF(context.Background(), apiErr) {
+			t.Error("expected no re-discovery when the AMF returned an HTTP error")
+		}
+	})
+	t.Run("wrapped pointer HTTP error from AMF -> no retry", func(t *testing.T) {
+		wrapped := fmt.Errorf("n1n2 transfer: %w", &openapi.GenericOpenAPIError{})
+		if shouldRediscoverAMF(context.Background(), wrapped) {
+			t.Error("expected no re-discovery for a wrapped *GenericOpenAPIError")
+		}
+	})
+	t.Run("HTTP error from AMF (value) -> no retry", func(t *testing.T) {
+		var apiErr error = openapi.GenericOpenAPIError{}
+		if shouldRediscoverAMF(context.Background(), apiErr) {
+			t.Error("expected no re-discovery for a value GenericOpenAPIError")
+		}
+	})
+}
+
+func amfDiscoveryProfile(nfInstanceId, apiPrefix string) models.NFProfileDiscovery {
+	return models.NFProfileDiscovery{
+		NfInstanceId: nfInstanceId,
+		NfType:       models.NFTYPE_AMF,
+		NfStatus:     models.NFSTATUS_REGISTERED,
+		NfServices: []models.NFService{
+			{ServiceName: models.SERVICENAME_NAMF_COMM, ApiPrefix: openapi.PtrString(apiPrefix)},
+		},
+	}
+}
+
+func ids(profiles []models.NFProfileDiscovery) []string {
+	out := make([]string, 0, len(profiles))
+	for i := range profiles {
+		out = append(out, profiles[i].GetNfInstanceId())
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Different NfInstanceIds come first; the one matching the failed id is moved last
+// (NOT dropped) — its NRF profile may carry a refreshed ApiPrefix.
+func TestOrderAmfCandidates_FailedIdMovedLast(t *testing.T) {
+	a := amfDiscoveryProfile("amf-a", "http://10.42.0.10:29518")
+	b := amfDiscoveryProfile("amf-b", "http://10.42.0.20:29518")
+	c := amfDiscoveryProfile("amf-c", "http://10.42.0.30:29518")
+
+	got := orderAmfCandidates([]models.NFProfileDiscovery{a, b, c}, "amf-b")
+	want := []string{"amf-a", "amf-c", "amf-b"}
+	if !equalStrings(ids(got), want) {
+		t.Errorf("expected order %v, got %v", want, ids(got))
+	}
+}
+
+// Pattern B: AMF re-registered in place — same NfInstanceId, new ApiPrefix.
+// The same-id candidate MUST still be returned (so it gets retried with the
+// refreshed endpoint), not filtered out.
+func TestOrderAmfCandidates_SameIdRetainedForInPlaceReRegistration(t *testing.T) {
+	refreshed := amfDiscoveryProfile("amf-stable", "http://10.42.0.99:29518") // new endpoint, same id
+
+	got := orderAmfCandidates([]models.NFProfileDiscovery{refreshed}, "amf-stable")
+	if len(got) != 1 {
+		t.Fatalf("expected the same-id candidate to be retained for in-place re-registration, got %d", len(got))
+	}
+	if got[0].GetNfInstanceId() != "amf-stable" {
+		t.Errorf("expected amf-stable, got %s", got[0].GetNfInstanceId())
+	}
+	svc := got[0].GetNfServices()
+	if len(svc) == 0 || svc[0].GetApiPrefix() != "http://10.42.0.99:29518" {
+		t.Errorf("expected refreshed ApiPrefix to be preserved, got %+v", svc)
+	}
+}
+
+func TestOrderAmfCandidates_PreservesOrderWhenNoMatch(t *testing.T) {
+	a := amfDiscoveryProfile("amf-a", "http://10.42.0.10:29518")
+	b := amfDiscoveryProfile("amf-b", "http://10.42.0.20:29518")
+	c := amfDiscoveryProfile("amf-c", "http://10.42.0.30:29518")
+
+	got := orderAmfCandidates([]models.NFProfileDiscovery{a, b, c}, "does-not-match-any")
+	want := []string{"amf-a", "amf-b", "amf-c"}
+	if !equalStrings(ids(got), want) {
+		t.Errorf("expected unchanged order %v, got %v", want, ids(got))
+	}
+}
+
+func TestOrderAmfCandidates_EmptyInput(t *testing.T) {
+	if got := orderAmfCandidates(nil, "anything"); len(got) != 0 {
+		t.Errorf("expected empty result for nil input, got %d", len(got))
+	}
+}

--- a/context/db.go
+++ b/context/db.go
@@ -326,6 +326,7 @@ func GetSMContextByRefInDB(ref string) (smContext *SMContext) {
 			logger.DataRepoLog.Errorf("smContext unmarshall error: %v", err)
 			return nil
 		}
+		smContext.RebuildCommunicationClient()
 	} else {
 		logger.DataRepoLog.Warnf("SmContext doesn't exist with ref: %v", ref)
 		return nil

--- a/context/db.go
+++ b/context/db.go
@@ -323,6 +323,7 @@ func GetSMContextByRefInDB(ref string) (smContext *SMContext) {
 			logger.DataRepoLog.Errorf("smContext unmarshall error: %v", err)
 			return nil
 		}
+		smContext.RebuildCommunicationClient()
 	} else {
 		logger.DataRepoLog.Warnf("SmContext doesn't exist with ref: %v", ref)
 		return nil

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -371,6 +371,23 @@ func (smContext *SMContext) SetCreateData(createData *models.SmContextCreateData
 	smContext.ServingNfId = createData.ServingNfId
 }
 
+// RebuildCommunicationClient reconstructs the Namf_Communication API client
+// from the stored AMFProfile. This is needed after recovering an SMContext from
+// MongoDB, since CommunicationClient is not serializable.
+func (smContext *SMContext) RebuildCommunicationClient() {
+	if smContext.AMFProfile.NfServices == nil {
+		return
+	}
+	for _, service := range *smContext.AMFProfile.NfServices {
+		if service.ServiceName == models.ServiceName_NAMF_COMM {
+			communicationConf := Namf_Communication.NewConfiguration()
+			communicationConf.SetBasePath(service.ApiPrefix)
+			smContext.CommunicationClient = Namf_Communication.NewAPIClient(communicationConf)
+			return
+		}
+	}
+}
+
 func (smContext *SMContext) BuildCreatedData() (createdData *models.SmContextCreatedData) {
 	createdData = new(models.SmContextCreatedData)
 	createdData.SNssai = smContext.Snssai

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -372,6 +372,27 @@ func (smContext *SMContext) SetCreateData(createData *models.SmContextCreateData
 	smContext.ServingNfId = createData.GetServingNfId()
 }
 
+// RebuildCommunicationClient reconstructs the Namf_Communication API client
+// from the stored AMFProfile. This is needed after recovering an SMContext from
+// MongoDB, since CommunicationClient is not serializable.
+func (smContext *SMContext) RebuildCommunicationClient() {
+	// Clear any existing client first so stale data does not linger if the
+	// (re-discovered) AMF profile has no namf-comm service.
+	smContext.CommunicationClient = nil
+	for _, service := range smContext.AMFProfile.GetNfServices() {
+		if service.GetServiceName() == models.SERVICENAME_NAMF_COMM {
+			communicationConf := Namf_Communication.NewConfiguration()
+			serverConfig := &communicationConf.Servers[0]
+			if apiRootVar, exists := serverConfig.Variables["apiRoot"]; exists {
+				apiRootVar.DefaultValue = service.GetApiPrefix()
+				serverConfig.Variables["apiRoot"] = apiRootVar
+			}
+			smContext.CommunicationClient = Namf_Communication.NewAPIClient(communicationConf)
+			return
+		}
+	}
+}
+
 func (smContext *SMContext) BuildCreatedData() (createdData *models.SmContextCreatedData) {
 	createdData = models.NewSmContextCreatedData()
 	createdData.SNssai = smContext.Snssai

--- a/context/sm_context_rebuild_test.go
+++ b/context/sm_context_rebuild_test.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Forsway Solutions AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omec-project/openapi/v2"
+	"github.com/omec-project/openapi/v2/models"
+)
+
+func amfProfileWithNamfComm(apiPrefix string) models.NFProfileDiscovery {
+	commService := models.NFService{
+		ServiceName: models.SERVICENAME_NAMF_COMM,
+		ApiPrefix:   openapi.PtrString(apiPrefix),
+	}
+	return models.NFProfileDiscovery{
+		NfInstanceId: "amf-instance-1",
+		NfType:       models.NFTYPE_AMF,
+		NfStatus:     models.NFSTATUS_REGISTERED,
+		NfServices:   []models.NFService{commService},
+	}
+}
+
+func TestRebuildCommunicationClient_WithNamfComm_BuildsClientAndSetsApiRoot(t *testing.T) {
+	const apiPrefix = "http://10.42.0.42:29518"
+
+	smCtx := &SMContext{}
+	smCtx.AMFProfile = amfProfileWithNamfComm(apiPrefix)
+
+	smCtx.RebuildCommunicationClient()
+
+	if smCtx.CommunicationClient == nil {
+		t.Fatalf("expected CommunicationClient to be non-nil after RebuildCommunicationClient")
+	}
+	// Ensure the apiRoot variable was wired through to the configuration.
+	cfg := smCtx.CommunicationClient.GetConfig()
+	if cfg == nil || len(cfg.Servers) == 0 {
+		t.Fatalf("expected client configuration with at least one server")
+	}
+	apiRootVar, ok := cfg.Servers[0].Variables["apiRoot"]
+	if !ok {
+		t.Fatalf("expected apiRoot variable to be present on server[0]")
+	}
+	if apiRootVar.DefaultValue != apiPrefix {
+		t.Errorf("apiRoot DefaultValue = %q, want %q", apiRootVar.DefaultValue, apiPrefix)
+	}
+}
+
+func TestRebuildCommunicationClient_NoServices_LeavesClientNil(t *testing.T) {
+	smCtx := &SMContext{}
+	// AMFProfile.NfServices is nil here.
+
+	smCtx.RebuildCommunicationClient()
+
+	if smCtx.CommunicationClient != nil {
+		t.Errorf("expected CommunicationClient to remain nil when NfServices is nil")
+	}
+}
+
+func TestRebuildCommunicationClient_NoNamfComm_LeavesClientNil(t *testing.T) {
+	apiPrefix := "http://10.42.0.42:29518"
+	smCtx := &SMContext{}
+	smCtx.AMFProfile = models.NFProfileDiscovery{
+		NfInstanceId: "amf-instance-2",
+		NfType:       models.NFTYPE_AMF,
+		NfStatus:     models.NFSTATUS_REGISTERED,
+		NfServices: []models.NFService{
+			{ServiceName: models.SERVICENAME_NAMF_EVTS, ApiPrefix: openapi.PtrString(apiPrefix)},
+		},
+	}
+
+	smCtx.RebuildCommunicationClient()
+
+	if smCtx.CommunicationClient != nil {
+		t.Errorf("expected CommunicationClient to remain nil when no namf-comm service is present")
+	}
+}
+
+// Belt-and-braces: a fresh build replaces any previously held client.
+func TestRebuildCommunicationClient_RebuildReplacesExistingClient(t *testing.T) {
+	const firstApiPrefix = "http://10.42.0.10:29518"
+	const secondApiPrefix = "http://10.42.0.20:29518"
+
+	smCtx := &SMContext{}
+	smCtx.AMFProfile = amfProfileWithNamfComm(firstApiPrefix)
+	smCtx.RebuildCommunicationClient()
+	if smCtx.CommunicationClient == nil {
+		t.Fatalf("setup: expected non-nil CommunicationClient after first build")
+	}
+	first := smCtx.CommunicationClient
+
+	smCtx.AMFProfile = amfProfileWithNamfComm(secondApiPrefix)
+	smCtx.RebuildCommunicationClient()
+
+	if smCtx.CommunicationClient == nil {
+		t.Fatalf("expected non-nil CommunicationClient after second build")
+	}
+	if smCtx.CommunicationClient == first {
+		t.Errorf("expected a fresh CommunicationClient instance after rebuild, got the same pointer")
+	}
+	apiRootVar := smCtx.CommunicationClient.GetConfig().Servers[0].Variables["apiRoot"]
+	if !strings.Contains(apiRootVar.DefaultValue, "10.42.0.20") {
+		t.Errorf("apiRoot DefaultValue = %q, expected it to reflect the second AMF endpoint", apiRootVar.DefaultValue)
+	}
+}

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -12,6 +12,7 @@ import (
 	"net"
 
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/smf/consumer"
 	smf_context "github.com/omec-project/smf/context"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
@@ -732,9 +733,7 @@ func HandlePfcpSessionReportRequest(msg *udp.Message) {
 				},
 			}
 
-			rspData, _, err := smContext.CommunicationClient.
-				N1N2MessageCollectionDocumentApi.
-				N1N2MessageTransfer(context.Background(), smContext.Supi, n1n2Request)
+			rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
 			if err != nil {
 				smContext.SubPfcpLog.Warnf("Send N1N2Transfer failed")
 			}

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/omec-project/openapi/v2"
 	"github.com/omec-project/openapi/v2/models"
+	"github.com/omec-project/smf/consumer"
 	smf_context "github.com/omec-project/smf/context"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
@@ -757,26 +758,17 @@ func HandlePfcpSessionReportRequest(msg *udp.Message) {
 					},
 				}
 
-				apiN1N2MessageTransferRequest := smContext.CommunicationClient.N1N2MessageCollectionCollectionAPI.N1N2MessageTransfer(context.Background(), smContext.Supi)
-				apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.N1N2MessageTransferReqData(n1n2Request.GetJsonData())
-				if binaryDataN1Message := n1n2Request.GetBinaryDataN1Message(); binaryDataN1Message != nil {
-					apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN1Message(binaryDataN1Message)
+				rspData, n1n2Err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, &n1n2Request)
+				if n1n2Err != nil {
+					smContext.SubPfcpLog.Warnf("Send N1N2Transfer failed: %v", n1n2Err)
 				}
-				if binaryDataN2Information := n1n2Request.GetBinaryDataN2Information(); binaryDataN2Information != nil {
-					apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN2Information(binaryDataN2Information)
-				}
-				var rspData *models.N1N2MessageTransferRspData
-				rspData, _, err = smContext.CommunicationClient.N1N2MessageCollectionCollectionAPI.N1N2MessageTransferExecute(apiN1N2MessageTransferRequest)
-				if err != nil {
-					smContext.SubPfcpLog.Warnf("Send N1N2Transfer failed")
-				}
-				if err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE {
+				if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE {
 					smContext.SubPfcpLog.Infof("Receive %v, AMF is able to page the UE", rspData.Cause)
 
 					pfcpSRflag.Drobu = false
 					cause = ie.CauseRequestAccepted
 				}
-				if err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_UE_NOT_RESPONDING {
+				if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_UE_NOT_RESPONDING {
 					smContext.SubPfcpLog.Infof("Receive %v, UE is not responding to N1N2 transfer message", rspData.Cause)
 					// TODO: TS 23.502 4.2.3.3 3c. Failure indication
 				}

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/openapi/models"
+	"github.com/omec-project/smf/consumer"
 	smf_context "github.com/omec-project/smf/context"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
@@ -487,10 +488,7 @@ func handleSendPfcpSessEstReqError(msg message.Message, pfcpErr error) {
 	}
 
 	// Send N1N2 Reject request
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionDocumentApi.
-		N1N2MessageTransfer(context.Background(), smContext.Supi, n1n2Request)
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
 	smContext.ChangeState(smf_context.SmStateInit)
 	smContext.SubCtxLog.Debugln("SMContextState Change State:", smContext.SMContextState.String())
 	if err != nil {

--- a/pfcp/message/send.go
+++ b/pfcp/message/send.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/omec-project/nas/v2/nasMessage"
 	"github.com/omec-project/openapi/v2/models"
+	"github.com/omec-project/smf/consumer"
 	smf_context "github.com/omec-project/smf/context"
 	"github.com/omec-project/smf/factory"
 	"github.com/omec-project/smf/logger"
@@ -502,24 +503,14 @@ func handleSendPfcpSessEstReqError(msg message.Message, pfcpErr error) {
 		}
 	}
 
-	// Send N1N2 Reject request
-	apiN1N2MessageTransferRequest := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransfer(context.Background(), smContext.Supi)
-	apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.N1N2MessageTransferReqData(n1n2Request.GetJsonData())
-	if binaryDataN1Message := n1n2Request.GetBinaryDataN1Message(); binaryDataN1Message != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN1Message(binaryDataN1Message)
-	}
-	if binaryDataN2Information := n1n2Request.GetBinaryDataN2Information(); binaryDataN2Information != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN2Information(binaryDataN2Information)
-	}
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransferExecute(apiN1N2MessageTransferRequest)
+	// Send N1N2 Reject request. Hold SMLock across the transfer (AMF re-discovery may
+	// mutate AMFProfile/ServingNfId/CommunicationClient) and the state transition so the
+	// SMContext stays consistent against concurrent users.
+	smContext.SMLock.Lock()
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
 	smContext.ChangeState(smf_context.SmStateInit)
 	smContext.SubCtxLog.Debugln("SMContextState Change State:", smContext.SMContextState.String())
+	smContext.SMLock.Unlock()
 	if err != nil {
 		smContext.SubPfcpLog.Warnln("send N1N2Transfer failed")
 	}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -119,10 +119,7 @@ func BuildAndSendQosN1N2TransferMsg(smContext *smfContext.SMContext) error {
 	}
 
 	smContext.SubPduSessLog.Infoln("QoS N1N2 transfer initiated")
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionDocumentApi.
-		N1N2MessageTransfer(context.Background(), smContext.Supi, n1n2Request)
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
 	if err != nil {
 		smContext.SubPfcpLog.Warnf("send N1N2Transfer failed, %v", err.Error())
 		return err

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -140,21 +140,11 @@ func BuildAndSendQosN1N2TransferMsg(smContext *smfContext.SMContext) error {
 	}
 
 	smContext.SubPduSessLog.Infoln("QoS N1N2 transfer initiated")
-	apiN1N2MessageTransferRequest := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransfer(context.Background(), smContext.Supi)
-	apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.N1N2MessageTransferReqData(n1n2Request.GetJsonData())
-	if binaryDataN1Message := n1n2Request.GetBinaryDataN1Message(); binaryDataN1Message != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN1Message(binaryDataN1Message)
-	}
-	if binaryDataN2Information := n1n2Request.GetBinaryDataN2Information(); binaryDataN2Information != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN2Information(binaryDataN2Information)
-	}
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransferExecute(apiN1N2MessageTransferRequest)
+	// Hold SMLock across the transfer so AMF re-discovery's mutation of
+	// AMFProfile/ServingNfId/CommunicationClient doesn't race with other SMContext users.
+	smContext.SMLock.Lock()
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, &n1n2Request)
+	smContext.SMLock.Unlock()
 	if err != nil {
 		smContext.SubPfcpLog.Warnf("send N1N2Transfer failed, %v", err.Error())
 		return err

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -15,7 +15,6 @@ import (
 	"github.com/omec-project/nas"
 	"github.com/omec-project/nas/nasMessage"
 	"github.com/omec-project/openapi"
-	"github.com/omec-project/openapi/Namf_Communication"
 	"github.com/omec-project/openapi/Nsmf_PDUSession"
 	"github.com/omec-project/openapi/Nudm_SubscriberDataManagement"
 	"github.com/omec-project/openapi/models"
@@ -284,13 +283,7 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 		smContext.SubPduSessLog.Debugln("PDUSessionSMContextCreate, Send NF Discovery Serving AMF success")
 	}
 
-	for _, service := range *smContext.AMFProfile.NfServices {
-		if service.ServiceName == models.ServiceName_NAMF_COMM {
-			communicationConf := Namf_Communication.NewConfiguration()
-			communicationConf.SetBasePath(service.ApiPrefix)
-			smContext.CommunicationClient = Namf_Communication.NewAPIClient(communicationConf)
-		}
-	}
+	smContext.RebuildCommunicationClient()
 
 	response.JsonData = smContext.BuildCreatedData()
 	txn.Rsp = &httpwrapper.Response{
@@ -703,10 +696,7 @@ func SendPduSessN1N2Transfer(smContext *smf_context.SMContext, success bool) err
 	}
 
 	smContext.SubPduSessLog.Infof("N1N2 transfer initiated")
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionDocumentApi.
-		N1N2MessageTransfer(context.Background(), smContext.Supi, n1n2Request)
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
 	if err != nil {
 		smContext.SubPfcpLog.Warnf("send N1N2Transfer failed, %v ", err.Error())
 		err = smContext.CommitSmPolicyDecision(false)

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/omec-project/nas/v2"
 	"github.com/omec-project/nas/v2/nasMessage"
-	"github.com/omec-project/openapi/v2/Namf_Communication"
 	"github.com/omec-project/openapi/v2/models"
 	"github.com/omec-project/smf/consumer"
 	smf_context "github.com/omec-project/smf/context"
@@ -393,17 +392,7 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 		smContext.SubPduSessLog.Debugln("PDUSessionSMContextCreate, Send NF Discovery Serving AMF success")
 	}
 
-	for _, service := range smContext.AMFProfile.NfServices {
-		if service.ServiceName == models.SERVICENAME_NAMF_COMM {
-			communicationConf := Namf_Communication.NewConfiguration()
-			serverConfig := &communicationConf.Servers[0]
-			if apiRootVar, exists := serverConfig.Variables["apiRoot"]; exists {
-				apiRootVar.DefaultValue = service.GetApiPrefix()
-				serverConfig.Variables["apiRoot"] = apiRootVar
-			}
-			smContext.CommunicationClient = Namf_Communication.NewAPIClient(communicationConf)
-		}
-	}
+	smContext.RebuildCommunicationClient()
 
 	response.JsonData = smContext.BuildCreatedData()
 	txn.Rsp = &httpwrapper.Response{
@@ -845,21 +834,12 @@ func SendPduSessN1N2Transfer(smContext *smf_context.SMContext, success bool) err
 	}
 
 	smContext.SubPduSessLog.Infof("N1N2 transfer initiated")
-	apiN1N2MessageTransferRequest := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransfer(context.Background(), smContext.Supi)
-	apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.N1N2MessageTransferReqData(n1n2Request.GetJsonData())
-	if binaryDataN1Message := n1n2Request.GetBinaryDataN1Message(); binaryDataN1Message != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN1Message(binaryDataN1Message)
-	}
-	if binaryDataN2Information := n1n2Request.GetBinaryDataN2Information(); binaryDataN2Information != nil {
-		apiN1N2MessageTransferRequest = apiN1N2MessageTransferRequest.BinaryDataN2Information(binaryDataN2Information)
-	}
-	rspData, _, err := smContext.
-		CommunicationClient.
-		N1N2MessageCollectionCollectionAPI.
-		N1N2MessageTransferExecute(apiN1N2MessageTransferRequest)
+	// Hold SMLock across the transfer: AMF re-discovery may mutate
+	// AMFProfile/ServingNfId/CommunicationClient, which must not race with other
+	// SMContext users. Released before CommitSmPolicyDecision, which locks itself.
+	smContext.SMLock.Lock()
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
+	smContext.SMLock.Unlock()
 	if err != nil {
 		smContext.SubPfcpLog.Warnf("send N1N2Transfer failed, %v ", err.Error())
 		err = smContext.CommitSmPolicyDecision(false)


### PR DESCRIPTION
## Summary

Fixes #548.

After an AMF pod restart (rolling update, OOM, node drain, etc.), the SMF continues sending `N1N2MessageTransfer` to the dead pod IP. The UE never receives the PDU Session Establishment Accept, T3580 expires, and the only known recovery is to restart the SMF pod. See #548 for the full root-cause analysis.

This PR adds a defensive retry path that fails fast on a dead AMF endpoint, queries NRF directly (bypassing the cache), and tries every other AMF candidate until one responds. It also rebuilds the per-`SMContext` `CommunicationClient` after MongoDB recovery so post-SMF-restart sessions don't see a `nil` client.

## What changed

`consumer/nf_management.go` — new `SendN1N2TransferWithRediscovery(ctx, smContext, n1n2Request)`:
- First attempt with `context.WithTimeout(ctx, 5*time.Second)` so a dead endpoint fails inside the T3580 window (~16s) instead of the kernel TCP timeout (~60s+).
- On failure, fetches all AMF candidates from NRF directly (skipping the cache, which would return the same stale entry).
- Iterates through candidates whose `NfInstanceId` differs from the one that just failed; succeeds on the first live AMF, or returns the last error if all are dead.

`context/sm_context.go` — new `(*SMContext).RebuildCommunicationClient()` that reconstructs the HTTP client from the stored `AMFProfile`. Called from `context/db.go` after loading an SMContext from MongoDB so a recovered context has a usable client.

`producer/pdu_session.go`, `producer/callback.go`, `pfcp/handler/handler.go`, `pfcp/message/send.go` — the four direct call sites that previously did `smContext.CommunicationClient.N1N2MessageCollectionDocumentApi.N1N2MessageTransfer(...)` now go through the wrapper. Inline `Namf_Communication.NewAPIClient(...)` construction in `producer/pdu_session.go` is replaced by a call to `RebuildCommunicationClient()`.

Diff stat: 7 files, +134 / −23.

The happy path is unchanged — when the cached client succeeds (the common case) the wrapper returns immediately with no extra NRF roundtrip and no retry.

## Why iterate through every NRF candidate

Originally I picked one alternative AMF (the first one with a `NfInstanceId` different from the failed one) and retried once. That isn't enough when NRF holds multiple stale entries — observed live, NRF had three AMF profiles, two dead and one live, and the single-retry heuristic landed on a dead one and gave up. Iterating every candidate handles arbitrary NRF pollution at the cost of `5s × N_dead` recovery time, which is still well within the T3580 retransmission window for any realistic count.

## Why bypass the NRF cache on re-discovery

The SMF NRF cache (1-minute TTL, 15-minute eviction sweep) is keyed in part by `TargetNfInstanceId`. A targeted lookup by the old `ServingNfId` returns the stale cached entry. Because `rediscoverAMF` only runs after a confirmed failure, going straight to NRF is the right behaviour — we already know the cached value was wrong.

## Verification

A/B tested on two RKE2 clusters with UERANSIM gNB+UE:

| Scenario | Stock `rel-3.1.0` SMF | This PR |
|---|---|---|
| Baseline PDU session | success | success (unchanged) |
| `kubectl delete pod -l app=amf` then re-establish | T3580 expires 5×, procedure failure | Accept on first or second attempt, ~5–11s |
| Multiple stale NRF entries | permanent failure | iterates through dead entries, succeeds on the live AMF |

Captured SMF log when retry triggers:

```
N1N2 transfer initiated → old AMF 10.x.y.OLD (dead)
[5s timeout] N1N2Transfer failed (... i/o timeout), attempting AMF re-discovery
AMF re-discovery: querying NRF directly (bypassing cache)
AMF re-discovery retry 1: trying NfInstanceId 8e2dfca4-... → succeeded
N1N2 Transfer completed
```

## Scope and follow-ups

This is a defensive SMF-side fix. The underlying NRF stale-entry accumulation (no preStop deregistration, no heartbeat-based TTL) and the AMF-side reuse of stale `NfId`/`RegisterIPv4` from MongoDB on restart are tracked separately and need their own fixes. The change here works regardless of whether those land — and since pod restarts are routine in any K8s environment, hardening the SMF against stale endpoints seems valuable on its own.

I left three open questions in #548 for the maintainers (overall framing, single-PR vs split, test expectations). Happy to adjust based on your preference. If you'd like unit tests for `RebuildCommunicationClient` and the candidate-iteration logic, I can add them in a follow-up commit.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `gofmt -d` on changed files — clean
- [x] Live A/B test on two RKE2 clusters (UERANSIM)
- [x] Live verification on a third cluster after image deploy
