### PR TITLE
Omit zero-valued bit rate parameters from QoS flow descriptions

### DIFF
--- a/qos/qos_flow.go
+++ b/qos/qos_flow.go
@@ -136,23 +136,23 @@ func (d *QosFlowDescriptionsAuthorized) BuildAddQosFlowDescFromQoSDesc(qosData *
 	// 5QI
 	qfd.AddQosFlowParam5Qi(uint8(qosData.GetVar5qi()))
 
-	// MFBR uplink
-	if rate, ok := getNullableString(qosData.MaxbrUl); ok {
+	// MFBR uplink (omitted for unset, empty or zero rates; see isZeroBitRate)
+	if rate, ok := getNullableString(qosData.MaxbrUl); ok && !isZeroBitRate(rate) {
 		qfd.addQosFlowRateParam(rate, QFDParameterIdMfbrUl)
 	}
 
-	// MFBR downlink
-	if rate, ok := getNullableString(qosData.MaxbrDl); ok {
+	// MFBR downlink (omitted for unset, empty or zero rates; see isZeroBitRate)
+	if rate, ok := getNullableString(qosData.MaxbrDl); ok && !isZeroBitRate(rate) {
 		qfd.addQosFlowRateParam(rate, QFDParameterIdMfbrDl)
 	}
 
-	// GFBR uplink
-	if rate, ok := getNullableString(qosData.GbrUl); ok {
+	// GFBR uplink (omitted for unset, empty or zero rates; see isZeroBitRate)
+	if rate, ok := getNullableString(qosData.GbrUl); ok && !isZeroBitRate(rate) {
 		qfd.addQosFlowRateParam(rate, QFDParameterIdGfbrUl)
 	}
 
-	// GFBR downlink
-	if rate, ok := getNullableString(qosData.GbrDl); ok {
+	// GFBR downlink (omitted for unset, empty or zero rates; see isZeroBitRate)
+	if rate, ok := getNullableString(qosData.GbrDl); ok && !isZeroBitRate(rate) {
 		qfd.addQosFlowRateParam(rate, QFDParameterIdGfbrDl)
 	}
 
@@ -174,6 +174,30 @@ func getNullableString(value openapi.NullableString) (string, bool) {
 	}
 
 	return *resolved, true
+}
+
+// isZeroBitRate reports whether a bit rate string (e.g. "0 Mbps") must not be
+// encoded as a QoS flow description rate parameter. It returns true for an
+// explicit zero rate as well as for any value GetBitRate would otherwise turn
+// into a zero or nonsensical rate: fewer than two fields (a missing unit, e.g.
+// "10", which GetBitRate encodes as 0) and a value that does not fit the 16-bit
+// rate field (a negative or >65535 value, which would wrap to a bogus uint16).
+//
+// A zero rate is not a valid GFBR/MFBR parameter per 3GPP TS 24.501: these are
+// meaningful only for GBR flows, so a non-GBR flow (such as the default 5QI 9
+// flow) may carry an explicit zero MFBR in the policy decision. Encoding it has
+// been observed to make UEs (e.g. Qualcomm modems) reject the PDU Session
+// Establishment Accept with 5GSM cause 0x22 (Service option temporarily out of
+// order), so such parameters are omitted.
+func isZeroBitRate(sBitRate string) bool {
+	fields := strings.Fields(sBitRate)
+	if len(fields) < 2 {
+		return true
+	}
+	// ParseUint with bitSize 16 rejects negatives and values that would
+	// overflow the uint16 rate field GetBitRate encodes into.
+	rate, err := strconv.ParseUint(fields[0], 10, 16)
+	return err != nil || rate == 0
 }
 
 func GetBitRate(sBitRate string) (val uint16, unit uint8) {

--- a/qos/qos_flow_test.go
+++ b/qos/qos_flow_test.go
@@ -72,3 +72,75 @@ func TestBuildAuthorizedQosFlowDescriptionsSkipsExplicitNullRates(t *testing.T) 
 		t.Fatalf("Content mismatch. got = %v, want = %v", authorizedQosFlow.Content, expectedBytes)
 	}
 }
+
+// A non-GBR flow (e.g. the default 5QI 9 flow) may carry an explicit zero MFBR
+// in the policy decision. Encoding "0 Mbps" produces an invalid QoS flow rate
+// parameter that real UEs reject (5GSM cause 0x22), so it must be omitted even
+// though the NullableString is set and non-empty.
+func TestBuildAuthorizedQosFlowDescriptionsSkipsZeroRates(t *testing.T) {
+	var maxbrUl openapi.NullableString
+	var maxbrDl openapi.NullableString
+
+	maxbrUl.Set(openapi.PtrString("0 Mbps"))
+	maxbrDl.Set(openapi.PtrString("0 Mbps"))
+
+	smPolicyDecision := &models.SmPolicyDecision{}
+	smPolicyDecision.QosDecs = &map[string]models.QosData{
+		"zero-rates": {
+			QosId:   "9",
+			Var5qi:  openapi.PtrInt32(9),
+			MaxbrUl: maxbrUl,
+			MaxbrDl: maxbrDl,
+		},
+	}
+
+	smCtxtPolData := &qos.SmCtxtPolicyData{}
+	smCtxtPolData.Initialize()
+	smPolicyUpdates := qos.BuildSmPolicyUpdate(smCtxtPolData, smPolicyDecision)
+
+	authorizedQosFlow := qos.BuildAuthorizedQosFlowDescriptions(smPolicyUpdates)
+	// Only the 5QI parameter remains; both zero MFBR parameters are omitted.
+	expectedBytes := []byte{0x9, 0x20, 0x41, 0x1, 0x1, 0x9}
+
+	if !bytes.Equal(authorizedQosFlow.Content, expectedBytes) {
+		t.Fatalf("Content mismatch. got = %v, want = %v", authorizedQosFlow.Content, expectedBytes)
+	}
+}
+
+// Rate strings that GetBitRate cannot turn into a valid 16-bit positive rate
+// must also be omitted: a missing unit ("10") is encoded as 0, a negative value
+// ("-1 Mbps") wraps to a bogus uint16, and an oversized value ("100000 Mbps")
+// overflows the 16-bit rate field. All would otherwise reintroduce the invalid
+// rate parameter that this guard prevents.
+func TestBuildAuthorizedQosFlowDescriptionsSkipsMalformedRates(t *testing.T) {
+	var maxbrUl openapi.NullableString
+	var maxbrDl openapi.NullableString
+	var gbrUl openapi.NullableString
+
+	maxbrUl.Set(openapi.PtrString("10"))        // missing unit -> GetBitRate yields 0
+	maxbrDl.Set(openapi.PtrString("-1 Mbps"))   // negative -> rejected by ParseUint
+	gbrUl.Set(openapi.PtrString("100000 Mbps")) // > 65535 -> overflows uint16
+
+	smPolicyDecision := &models.SmPolicyDecision{}
+	smPolicyDecision.QosDecs = &map[string]models.QosData{
+		"malformed-rates": {
+			QosId:   "9",
+			Var5qi:  openapi.PtrInt32(9),
+			MaxbrUl: maxbrUl,
+			MaxbrDl: maxbrDl,
+			GbrUl:   gbrUl,
+		},
+	}
+
+	smCtxtPolData := &qos.SmCtxtPolicyData{}
+	smCtxtPolData.Initialize()
+	smPolicyUpdates := qos.BuildSmPolicyUpdate(smCtxtPolData, smPolicyDecision)
+
+	authorizedQosFlow := qos.BuildAuthorizedQosFlowDescriptions(smPolicyUpdates)
+	// Only the 5QI parameter remains; all three malformed rate parameters are omitted.
+	expectedBytes := []byte{0x9, 0x20, 0x41, 0x1, 0x1, 0x9}
+
+	if !bytes.Equal(authorizedQosFlow.Content, expectedBytes) {
+		t.Fatalf("Content mismatch. got = %v, want = %v", authorizedQosFlow.Content, expectedBytes)
+	}
+}


### PR DESCRIPTION
## Problem

A PDU session is created successfully at the network level, but the UE rejects it with **5GSM cause `0x22` (Service option temporarily out of order)**. This was observed against real UEs (Qualcomm modems) on a private 5G deployment.

The trigger is a QoS flow description in the *PDU Session Establishment Accept* that carries an **MFBR encoded as `0 Mbps`** for a non-GBR flow (the default 5QI 9 flow).

## Root cause

Per 3GPP TS 24.501, the GFBR/MFBR rate parameters in a QoS flow description are meaningful only for GBR flows. A non-GBR flow can therefore arrive in the SM policy decision with an explicit zero rate. `getNullableString()` already drops *unset* and *empty* rates, but a rate explicitly **set to `"0 Mbps"`** passes through and gets encoded as a zero-valued rate parameter, which is invalid and rejected by the UE.

## Fix

Skip any GFBR/MFBR parameter whose resolved bit rate is zero. A small `isZeroBitRate()` helper is added and applied to all four rate-parameter sites (MFBR/GFBR, UL/DL). Real GBR flows carry non-zero GFBR, so their encoding is unchanged.

## Testing

- New regression test `TestBuildAuthorizedQosFlowDescriptionsSkipsZeroRates` covers an explicit zero MFBR on a non-GBR (5QI 9) flow and asserts only the 5QI parameter is encoded.
- `go build ./...`, `go vet ./qos/...`, and `go test ./qos/...` all pass; existing QoS flow tests are unaffected.