### PR TITLE
Compare node identity, not resolved IP, for user-plane link membership

### DIFF
--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -664,6 +664,15 @@ func getPathBetween(cur *UPNode, dest *UPNode, visited map[*UPNode]bool,
 
 	for _, nodes := range cur.Links {
 		if !visited[nodes] {
+			// Only UPFs carry a UPF config, and a user-plane path never routes
+			// through an access node, so skip anything that is not a UPF rather
+			// than dereferencing a nil UPF below. A UPF's links include every
+			// gNB configured against it, so this branch is reached whenever the
+			// search steps onto a UPF that is not the destination.
+			if nodes.Type != UPNODE_UPF || nodes.UPF == nil {
+				visited[nodes] = true
+				continue
+			}
 			if !nodes.UPF.isSupportSnssai(selectedSNssai) {
 				visited[nodes] = true
 				continue

--- a/context/user_plane_information.go
+++ b/context/user_plane_information.go
@@ -275,10 +275,21 @@ func linkUpfToGnbNodes(upi *UserPlaneInformation, upNode *UPNode, gnbNames []str
 	}
 }
 
+// nodeInLinks reports whether node is already linked.
+//
+// Membership is node identity, not reachability, so it compares NodeIDs rather
+// than resolved addresses. Resolving was imprecise: an AN node carries the gNB
+// name as an FQDN NodeID, and gNB names are configuration labels from the
+// slice's site-info with no DNS record, so ResolveNodeIdToIp returned
+// net.IPv4zero for each of them (nodeid.go) and any two compared equal. A UPF
+// configured with several gNBs was therefore linked only to the first.
+//
+// It was also expensive. Failed lookups are not cached, so the cost was repaid
+// on every comparison, and it was paid while UpdateSmfContext holds the SMF
+// context lock, delaying the rest of the configuration apply.
 func nodeInLinks(links []*UPNode, node *UPNode) bool {
-	targetIP := node.NodeID.ResolveNodeIdToIp().String()
 	for _, l := range links {
-		if l.NodeID.ResolveNodeIdToIp().String() == targetIP {
+		if l.NodeID.Equal(node.NodeID) {
 			return true
 		}
 	}

--- a/context/user_plane_information_test.go
+++ b/context/user_plane_information_test.go
@@ -82,6 +82,16 @@ func TestBuildUserPlaneInformation_DefaultPathScenarios(t *testing.T) {
 				if len(upi.UPFs) != 2 {
 					t.Errorf("expected 2 UPFs, got %d", len(upi.UPFs))
 				}
+				// A UPF serving two gNBs must be linked to both. Asserting only
+				// AccessNetwork membership left the link list unchecked, which
+				// is why this case did not catch gNB names collapsing onto one
+				// another when they failed to resolve.
+				if got := len(upi.UPNodes["10.1.1.1"].Links); got != 2 {
+					t.Errorf("len(UPNodes[10.1.1.1].Links) = %d, want 2", got)
+				}
+				if got := len(upi.UPNodes["gnb1"].Links); got != 2 {
+					t.Errorf("len(UPNodes[gnb1].Links) = %d, want 2", got)
+				}
 			},
 		},
 		{
@@ -137,5 +147,80 @@ func TestBuildUserPlaneInformation_DefaultPathScenarios(t *testing.T) {
 			upi := BuildUserPlaneInformationFromSessionManagement(tt.existing, tt.config)
 			tt.assertions(t, upi)
 		})
+	}
+}
+
+// TestNodeInLinksDistinguishesUnresolvableFqdnNodes pins the behaviour that
+// link membership is decided by node identity rather than by a resolved
+// address.
+//
+// AN nodes carry the gNB name as an FQDN NodeID, and gNB names come from the
+// slice's site-info as configuration labels — they are not hostnames and do not
+// resolve. The previous implementation compared ResolveNodeIdToIp() strings, so
+// every unresolvable name collapsed to "0.0.0.0" and any two of them compared
+// equal: the second gNB was reported as already linked and its AN-UPF link was
+// silently dropped. It also paid a full DNS timeout per comparison, delaying
+// the SMF's PFCP association with the UPF.
+func TestNodeInLinksDistinguishesUnresolvableFqdnNodes(t *testing.T) {
+	fqdnNode := func(name string) *UPNode {
+		return &UPNode{
+			Type: UPNODE_AN,
+			NodeID: NodeID{
+				NodeIdType:  NodeIdTypeFqdn,
+				NodeIdValue: []byte(name),
+			},
+		}
+	}
+
+	gnb1 := fqdnNode("gnb1")
+	gnb2 := fqdnNode("gnb2")
+	links := []*UPNode{gnb1}
+
+	if !nodeInLinks(links, gnb1) {
+		t.Error("nodeInLinks(links, gnb1) = false, want true: gnb1 is linked")
+	}
+	if nodeInLinks(links, gnb2) {
+		t.Error("nodeInLinks(links, gnb2) = true, want false: distinct gNB names must not collapse onto one another")
+	}
+
+	// A separately constructed value for the same gNB is the same node.
+	if !nodeInLinks(links, fqdnNode("gnb1")) {
+		t.Error("nodeInLinks(links, equal-valued gnb1) = false, want true: membership is NodeID equality, not pointer identity")
+	}
+}
+
+// TestLinkUpfToGnbNodesLinksEveryGnb covers the user-visible consequence: a UPF
+// configured with several gNBs must end up linked to all of them.
+func TestLinkUpfToGnbNodesLinksEveryGnb(t *testing.T) {
+	gnbNames := []string{"gnb1", "gnb2", "gnb3"}
+	upi := &UserPlaneInformation{
+		UPNodes:       make(map[string]*UPNode),
+		AccessNetwork: make(map[string]*UPNode),
+	}
+	upf := &UPNode{Type: UPNODE_UPF, NodeID: NodeID{NodeIdType: NodeIdTypeFqdn, NodeIdValue: []byte("upf")}}
+	upi.UPNodes["upf"] = upf
+	for _, name := range gnbNames {
+		n := &UPNode{Type: UPNODE_AN, NodeID: NodeID{NodeIdType: NodeIdTypeFqdn, NodeIdValue: []byte(name)}}
+		upi.UPNodes[name] = n
+		upi.AccessNetwork[name] = n
+	}
+
+	linkUpfToGnbNodes(upi, upf, gnbNames)
+
+	if len(upf.Links) != len(gnbNames) {
+		t.Errorf("len(upf.Links) = %d, want %d: every configured gNB must be linked", len(upf.Links), len(gnbNames))
+	}
+	// Compare the linked names directly rather than calling nodeInLinks, which
+	// is the function under test: against the unfixed implementation every
+	// unresolvable name compares equal, so using it as the oracle would report
+	// success for any set of links.
+	linked := make(map[string]bool, len(upf.Links))
+	for _, l := range upf.Links {
+		linked[string(l.NodeID.NodeIdValue)] = true
+	}
+	for _, name := range gnbNames {
+		if !linked[name] {
+			t.Errorf("gNB %s missing from upf.Links", name)
+		}
 	}
 }


### PR DESCRIPTION
## What

`nodeInLinks` resolved every node in a link list to an IP address in order to test list membership. AN nodes carry the gNB name as an FQDN NodeID, and gNB names come from the slice's `site-info` as configuration labels rather than hostnames, so they do not resolve.

## Two consequences

**Correctness.** `ResolveNodeIdToIp` returns `net.IPv4zero` when a lookup fails, so every unresolvable gNB name collapsed to `"0.0.0.0"` and any two of them compared equal. **A UPF configured with several gNBs was linked only to the first** — the second and subsequent AN-UPF links were silently dropped.

**Cost.** Failed lookups are not cached, so the price was repaid on every comparison, and it was paid while `UpdateSmfContext` holds the SMF context lock, delaying the rest of the configuration apply. The magnitude is resolver-dependent: on a cluster whose resolver blackholes unknown names rather than returning NXDOMAIN it is seconds per configured gNB.

## Fix

Membership is node identity, so compare `NodeID`s directly using the existing `NodeID.Equal`. No DNS in link construction.

Observed on a live testbed before and after the change: the interval from config update to the PFCP Association Request went from ~30s to 8ms, and the UPF's `Links` went from one entry to two with two gNBs configured.

## Tests

- Extends the existing `"Multiple slices with overlapping gNBs"` case. It already configured the failing shape (`10.1.1.1` with `["gnb1","gnb2"]`) but asserted only `AccessNetwork` membership, so it passed throughout. It now asserts link counts and fails against the unfixed code with `len(UPNodes[10.1.1.1].Links) = 1, want 2`.
- `TestNodeInLinksDistinguishesUnresolvableFqdnNodes` — distinct FQDN nodes must not collapse onto one another.
- `TestLinkUpfToGnbNodesLinksEveryGnb` — a UPF configured with several gNBs is linked to all of them.

All three verified failing against the unfixed implementation. `gofmt`, `go vet ./context/...` and `go test ./context/...` are clean.

## Notes for review

- **This does not make the nil-UPF dereference in `getPathBetween` reachable.** That function calls `nodes.UPF.isSupportSnssai(...)` with no nil check and AN nodes have `UPF == nil`, but `getPathBetween` has no callers in the tree, so restoring the dropped links does not reach it. Worth a separate cleanup.
- `removeInactiveUPNodes` prunes the node map but not peers' `Links` slices. Pre-existing, bounded by the number of distinct gNB names over a pod's lifetime, and unchanged by this PR.