### PR TITLE
Send a 5GSM cause value in the PDU session establishment reject

### DIFF
--- a/smferrors/errors.go
+++ b/smferrors/errors.go
@@ -162,8 +162,8 @@ func NewExtProblemDetailsSystemFailure() models.ExtProblemDetails {
 }
 
 var ErrorCause = map[string]uint8{
-	"DnnDeniedError":                nasMessage.Cause5GMMDNNNotSupportedOrNotSubscribedInTheSlice,
-	"DnnNotSupported":               nasMessage.Cause5GMMDNNNotSupportedOrNotSubscribedInTheSlice,
+	"DnnDeniedError":                nasMessage.Cause5GSMMissingOrUnknownDNNInASlice,
+	"DnnNotSupported":               nasMessage.Cause5GSMMissingOrUnknownDNNInASlice,
 	"InsufficientResourceSliceDnn":  nasMessage.Cause5GSMInsufficientResourcesForSpecificSliceAndDNN,
 	"IpAllocError":                  nasMessage.Cause5GSMInsufficientResources,
 	"SubscriptionDataFetchError":    nasMessage.Cause5GSMRequestRejectedUnspecified,

--- a/smferrors/errors_test.go
+++ b/smferrors/errors_test.go
@@ -53,50 +53,6 @@ func TestNewExtProblemDetailsSystemFailure(t *testing.T) {
 	}
 }
 
-// valid5GSMCauses is the set of cause values defined for the 5GSM cause IE in 3GPP TS 24.501
-// clause 9.11.4.2 that the NAS library provides constants for.
-//
-// It is enumerated by value because these are untyped uint8 constants: Go keeps no name at
-// run time, so a test cannot ask whether a value "is a Cause5GSM* constant". Note that
-// nasMessage.Cause5GSMType is deliberately absent - despite the name it is the IEI of the
-// 5GSM cause IE, not a cause value.
-var valid5GSMCauses = map[uint8]string{
-	nasMessage.Cause5GSMInsufficientResources:                                       "Cause5GSMInsufficientResources",
-	nasMessage.Cause5GSMMissingOrUnknownDNN:                                         "Cause5GSMMissingOrUnknownDNN",
-	nasMessage.Cause5GSMUnknownPDUSessionType:                                       "Cause5GSMUnknownPDUSessionType",
-	nasMessage.Cause5GSMUserAuthenticationOrAuthorizationFailed:                     "Cause5GSMUserAuthenticationOrAuthorizationFailed",
-	nasMessage.Cause5GSMRequestRejectedUnspecified:                                  "Cause5GSMRequestRejectedUnspecified",
-	nasMessage.Cause5GSMServiceOptionTemporarilyOutOfOrder:                          "Cause5GSMServiceOptionTemporarilyOutOfOrder",
-	nasMessage.Cause5GSMPTIAlreadyInUse:                                             "Cause5GSMPTIAlreadyInUse",
-	nasMessage.Cause5GSMRegularDeactivation:                                         "Cause5GSMRegularDeactivation",
-	nasMessage.Cause5GSMReactivationRequested:                                       "Cause5GSMReactivationRequested",
-	nasMessage.Cause5GSMInvalidPDUSessionIdentity:                                   "Cause5GSMInvalidPDUSessionIdentity",
-	nasMessage.Cause5GSMSemanticErrorsInPacketFilter:                                "Cause5GSMSemanticErrorsInPacketFilter",
-	nasMessage.Cause5GSMSyntacticalErrorInPacketFilter:                              "Cause5GSMSyntacticalErrorInPacketFilter",
-	nasMessage.Cause5GSMOutOfLADNServiceArea:                                        "Cause5GSMOutOfLADNServiceArea",
-	nasMessage.Cause5GSMPTIMismatch:                                                 "Cause5GSMPTIMismatch",
-	nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed:                               "Cause5GSMPDUSessionTypeIPv4OnlyAllowed",
-	nasMessage.Cause5GSMPDUSessionTypeIPv6OnlyAllowed:                               "Cause5GSMPDUSessionTypeIPv6OnlyAllowed",
-	nasMessage.Cause5GSMPDUSessionDoesNotExist:                                      "Cause5GSMPDUSessionDoesNotExist",
-	nasMessage.Cause5GSMInsufficientResourcesForSpecificSliceAndDNN:                 "Cause5GSMInsufficientResourcesForSpecificSliceAndDNN",
-	nasMessage.Cause5GSMNotSupportedSSCMode:                                         "Cause5GSMNotSupportedSSCMode",
-	nasMessage.Cause5GSMInsufficientResourcesForSpecificSlice:                       "Cause5GSMInsufficientResourcesForSpecificSlice",
-	nasMessage.Cause5GSMMissingOrUnknownDNNInASlice:                                 "Cause5GSMMissingOrUnknownDNNInASlice",
-	nasMessage.Cause5GSMInvalidPTIValue:                                             "Cause5GSMInvalidPTIValue",
-	nasMessage.Cause5GSMMaximumDataRatePerUEForUserPlaneIntegrityProtectionIsTooLow: "Cause5GSMMaximumDataRatePerUEForUserPlaneIntegrityProtectionIsTooLow",
-	nasMessage.Cause5GSMSemanticErrorInTheQoSOperation:                              "Cause5GSMSemanticErrorInTheQoSOperation",
-	nasMessage.Cause5GSMSyntacticalErrorInTheQoSOperation:                           "Cause5GSMSyntacticalErrorInTheQoSOperation",
-	nasMessage.Cause5GSMInvalidMappedEPSBearerIdentity:                              "Cause5GSMInvalidMappedEPSBearerIdentity",
-	nasMessage.Cause5GSMSemanticallyIncorrectMessage:                                "Cause5GSMSemanticallyIncorrectMessage",
-	nasMessage.Cause5GSMInvalidMandatoryInformation:                                 "Cause5GSMInvalidMandatoryInformation",
-	nasMessage.Cause5GSMMessageTypeNonExistentOrNotImplemented:                      "Cause5GSMMessageTypeNonExistentOrNotImplemented",
-	nasMessage.Cause5GSMMessageTypeNotCompatibleWithTheProtocolState:                "Cause5GSMMessageTypeNotCompatibleWithTheProtocolState",
-	nasMessage.Cause5GSMInformationElementNonExistentOrNotImplemented:               "Cause5GSMInformationElementNonExistentOrNotImplemented",
-	nasMessage.Cause5GSMConditionalIEError:                                          "Cause5GSMConditionalIEError",
-	nasMessage.Cause5GSMMessageNotCompatibleWithTheProtocolState:                    "Cause5GSMMessageNotCompatibleWithTheProtocolState",
-	nasMessage.Cause5GSMProtocolErrorUnspecified:                                    "Cause5GSMProtocolErrorUnspecified",
-}
-
 // TestErrorCauseValuesAre5GSMCauses guards the whole ErrorCause table. Every value in it is
 // written into the 5GSM cause IE of a PDU SESSION ESTABLISHMENT REJECT or a PDU SESSION
 // RELEASE REJECT, so a value from another register - 5GMM causes are the easy mistake, since
@@ -107,7 +63,11 @@ var valid5GSMCauses = map[uint8]string{
 // silently collapses into the generic cause and the UE cannot tell the difference.
 func TestErrorCauseValuesAre5GSMCauses(t *testing.T) {
 	for key, value := range ErrorCause {
-		if name, ok := valid5GSMCauses[value]; !ok {
+		// Cause5GSMToString returns the empty string for a value TS 24.501 does not define, which
+		// is the same contract Cause5GMMToString has. The set used to be duplicated here; nas
+		// v2.2.1 carries it, so the library that owns the constants owns the answer too.
+		name := nasMessage.Cause5GSMToString(value)
+		if name == "" {
 			t.Errorf("ErrorCause[%q] = %#02x, which is not a cause value defined for the 5GSM cause IE; "+
 				"a UE would decode it as #31 \"request rejected, unspecified\" per TS 24.501 clause 9.11.4.2", key, value)
 		} else if testing.Verbose() {

--- a/smferrors/errors_test.go
+++ b/smferrors/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/omec-project/nas/v2/nasMessage"
 	"github.com/omec-project/openapi/v2/utils"
 )
 
@@ -49,5 +50,89 @@ func TestNewExtProblemDetailsSystemFailure(t *testing.T) {
 	}
 	if pd.GetCause() != utils.CauseSystemFailure {
 		t.Fatalf("expected cause %q, got %q", utils.CauseSystemFailure, pd.GetCause())
+	}
+}
+
+// valid5GSMCauses is the set of cause values defined for the 5GSM cause IE in 3GPP TS 24.501
+// clause 9.11.4.2 that the NAS library provides constants for.
+//
+// It is enumerated by value because these are untyped uint8 constants: Go keeps no name at
+// run time, so a test cannot ask whether a value "is a Cause5GSM* constant". Note that
+// nasMessage.Cause5GSMType is deliberately absent - despite the name it is the IEI of the
+// 5GSM cause IE, not a cause value.
+var valid5GSMCauses = map[uint8]string{
+	nasMessage.Cause5GSMInsufficientResources:                                       "Cause5GSMInsufficientResources",
+	nasMessage.Cause5GSMMissingOrUnknownDNN:                                         "Cause5GSMMissingOrUnknownDNN",
+	nasMessage.Cause5GSMUnknownPDUSessionType:                                       "Cause5GSMUnknownPDUSessionType",
+	nasMessage.Cause5GSMUserAuthenticationOrAuthorizationFailed:                     "Cause5GSMUserAuthenticationOrAuthorizationFailed",
+	nasMessage.Cause5GSMRequestRejectedUnspecified:                                  "Cause5GSMRequestRejectedUnspecified",
+	nasMessage.Cause5GSMServiceOptionTemporarilyOutOfOrder:                          "Cause5GSMServiceOptionTemporarilyOutOfOrder",
+	nasMessage.Cause5GSMPTIAlreadyInUse:                                             "Cause5GSMPTIAlreadyInUse",
+	nasMessage.Cause5GSMRegularDeactivation:                                         "Cause5GSMRegularDeactivation",
+	nasMessage.Cause5GSMReactivationRequested:                                       "Cause5GSMReactivationRequested",
+	nasMessage.Cause5GSMInvalidPDUSessionIdentity:                                   "Cause5GSMInvalidPDUSessionIdentity",
+	nasMessage.Cause5GSMSemanticErrorsInPacketFilter:                                "Cause5GSMSemanticErrorsInPacketFilter",
+	nasMessage.Cause5GSMSyntacticalErrorInPacketFilter:                              "Cause5GSMSyntacticalErrorInPacketFilter",
+	nasMessage.Cause5GSMOutOfLADNServiceArea:                                        "Cause5GSMOutOfLADNServiceArea",
+	nasMessage.Cause5GSMPTIMismatch:                                                 "Cause5GSMPTIMismatch",
+	nasMessage.Cause5GSMPDUSessionTypeIPv4OnlyAllowed:                               "Cause5GSMPDUSessionTypeIPv4OnlyAllowed",
+	nasMessage.Cause5GSMPDUSessionTypeIPv6OnlyAllowed:                               "Cause5GSMPDUSessionTypeIPv6OnlyAllowed",
+	nasMessage.Cause5GSMPDUSessionDoesNotExist:                                      "Cause5GSMPDUSessionDoesNotExist",
+	nasMessage.Cause5GSMInsufficientResourcesForSpecificSliceAndDNN:                 "Cause5GSMInsufficientResourcesForSpecificSliceAndDNN",
+	nasMessage.Cause5GSMNotSupportedSSCMode:                                         "Cause5GSMNotSupportedSSCMode",
+	nasMessage.Cause5GSMInsufficientResourcesForSpecificSlice:                       "Cause5GSMInsufficientResourcesForSpecificSlice",
+	nasMessage.Cause5GSMMissingOrUnknownDNNInASlice:                                 "Cause5GSMMissingOrUnknownDNNInASlice",
+	nasMessage.Cause5GSMInvalidPTIValue:                                             "Cause5GSMInvalidPTIValue",
+	nasMessage.Cause5GSMMaximumDataRatePerUEForUserPlaneIntegrityProtectionIsTooLow: "Cause5GSMMaximumDataRatePerUEForUserPlaneIntegrityProtectionIsTooLow",
+	nasMessage.Cause5GSMSemanticErrorInTheQoSOperation:                              "Cause5GSMSemanticErrorInTheQoSOperation",
+	nasMessage.Cause5GSMSyntacticalErrorInTheQoSOperation:                           "Cause5GSMSyntacticalErrorInTheQoSOperation",
+	nasMessage.Cause5GSMInvalidMappedEPSBearerIdentity:                              "Cause5GSMInvalidMappedEPSBearerIdentity",
+	nasMessage.Cause5GSMSemanticallyIncorrectMessage:                                "Cause5GSMSemanticallyIncorrectMessage",
+	nasMessage.Cause5GSMInvalidMandatoryInformation:                                 "Cause5GSMInvalidMandatoryInformation",
+	nasMessage.Cause5GSMMessageTypeNonExistentOrNotImplemented:                      "Cause5GSMMessageTypeNonExistentOrNotImplemented",
+	nasMessage.Cause5GSMMessageTypeNotCompatibleWithTheProtocolState:                "Cause5GSMMessageTypeNotCompatibleWithTheProtocolState",
+	nasMessage.Cause5GSMInformationElementNonExistentOrNotImplemented:               "Cause5GSMInformationElementNonExistentOrNotImplemented",
+	nasMessage.Cause5GSMConditionalIEError:                                          "Cause5GSMConditionalIEError",
+	nasMessage.Cause5GSMMessageNotCompatibleWithTheProtocolState:                    "Cause5GSMMessageNotCompatibleWithTheProtocolState",
+	nasMessage.Cause5GSMProtocolErrorUnspecified:                                    "Cause5GSMProtocolErrorUnspecified",
+}
+
+// TestErrorCauseValuesAre5GSMCauses guards the whole ErrorCause table. Every value in it is
+// written into the 5GSM cause IE of a PDU SESSION ESTABLISHMENT REJECT or a PDU SESSION
+// RELEASE REJECT, so a value from another register - 5GMM causes are the easy mistake, since
+// their names describe the same conditions - is a defect even when the name reads correctly.
+//
+// TS 24.501 clause 9.11.4.2 requires a UE receiving an undefined 5GSM cause to treat it as
+// #31 "request rejected, unspecified", so a wrong-register value does not fail loudly. It
+// silently collapses into the generic cause and the UE cannot tell the difference.
+func TestErrorCauseValuesAre5GSMCauses(t *testing.T) {
+	for key, value := range ErrorCause {
+		if name, ok := valid5GSMCauses[value]; !ok {
+			t.Errorf("ErrorCause[%q] = %#02x, which is not a cause value defined for the 5GSM cause IE; "+
+				"a UE would decode it as #31 \"request rejected, unspecified\" per TS 24.501 clause 9.11.4.2", key, value)
+		} else if testing.Verbose() {
+			t.Logf("ErrorCause[%q] = %s", key, name)
+		}
+	}
+}
+
+// TestDnnRejectCausesAreSliceScoped pins the DNN rejection causes to #70 rather than #27.
+//
+// The two differ only in scope, and the scope is not cosmetic: per TS 24.501 clause 6.4.1.4.2
+// a UE receiving #27 backs off the [PLMN, DNN] combination, suppressing that DNN across every
+// slice, while #70 scopes the back-off to [PLMN, DNN, S-NSSAI]. RetrieveDnnInformation matches
+// the S-NSSAI before looking up the DNN, so it never determines anything about the DNN in
+// another slice - sending #27 would deny the subscriber a DNN that may be correctly configured
+// elsewhere.
+func TestDnnRejectCausesAreSliceScoped(t *testing.T) {
+	for _, key := range []string{"DnnNotSupported", "DnnDeniedError"} {
+		got, ok := ErrorCause[key]
+		if !ok {
+			t.Fatalf("ErrorCause has no entry for %q", key)
+		}
+		if got != nasMessage.Cause5GSMMissingOrUnknownDNNInASlice {
+			t.Errorf("ErrorCause[%q] = %#02x, want Cause5GSMMissingOrUnknownDNNInASlice (%#02x): the DNN lookup is slice-scoped",
+				key, got, nasMessage.Cause5GSMMissingOrUnknownDNNInASlice)
+		}
 	}
 }


### PR DESCRIPTION
## The defect

`smferrors.ErrorCause` maps the two DNN keys to
`nasMessage.Cause5GMMDNNNotSupportedOrNotSubscribedInTheSlice` — `0x5b`, 91. That is a
**5GMM** cause value, and every consumer of this table writes it into the **5GSM** cause IE:

- `context/sm_context.go` → `GeneratePDUSessionEstablishmentReject` → `BuildGSMPDUSessionEstablishmentReject`
- `context/gsm_build.go` → `BuildGSMPDUSessionReleaseRejectWithCause`

5GMM and 5GSM are separate registers in TS 24.501, and 91 is not assigned in the 5GSM one
(table 9.11.4.2.1).

The name is why this is easy to miss. "DNN not supported or not subscribed in the slice"
describes exactly what the SMF wants to say — and the same constant is *correct* in the AMF,
which puts it in the `Cause5GMM` IE of a DL NAS TRANSPORT.

## Why it is quiet rather than loud

TS 24.501 clause 9.11.4.2 requires a UE receiving an undefined 5GSM cause to treat it as
`31 "request rejected, unspecified"`. That is what twelve other entries in this same table
already send, so the DNN-specific signal is not rejected — it is silently flattened into the
generic one, and the UE cannot tell the two apart.

## Why `70` and not `27`

Both are in clause 6.4.1.4's list of causes the SMF sends for a refused establishment. They
differ only in scope, and the scope is normative, not cosmetic:

| Cause | UE back-off scope (clause 6.4.1.4.2) |
|---|---|
| `27` missing or unknown DNN | `[PLMN, DNN]` — suppresses that DNN across **every** slice |
| `70` missing or unknown DNN in a slice | `[PLMN, DNN, S-NSSAI]` |

The annex descriptions are identical except that `70` adds ", in the slice".

`RetrieveDnnInformation` matches the S-NSSAI first and only then looks up `DnnInfos[dnn]`, so
when it returns nil the SMF has determined nothing about that DNN in any other slice. Sending
`27` would therefore assert more than was established, and would stop a UE retrying a DNN
that may be correctly configured on another slice.

The same branch also fires when the requested S-NSSAI matches nothing at all. `70` still
reads correctly there — the DNN could not be resolved in that slice — and clause 6.4.1.4
offers no 5GSM value for an unknown slice, because slice admission is decided at 5GMM by the
AMF before the SMF is involved.

## On `DnnDeniedError`

It has no raise site anywhere in the tree — only its definition and its two map entries. Its
value is corrected rather than the entry removed, so the table-wide test below holds. Removing
pre-existing dead code is deliberately left out of a defect fix; flagging it here instead.

## Tests

- `TestErrorCauseValuesAre5GSMCauses` asserts every value in `ErrorCause` is a cause defined
  for the 5GSM cause IE, so a future 5GMM entry fails in CI instead of on the air interface.
  It checks by **value**: these are untyped `uint8` constants, so Go keeps no name at run time
  and a test cannot ask whether something "is a `Cause5GSM*` constant".
- `TestDnnRejectCausesAreSliceScoped` pins the DNN entries to `70` and records the back-off
  reasoning, so the scope decision is not silently reverted later.

Both were mutation-verified: restoring the 5GMM value makes them fail, naming the key and the
value.

## Note

There is a companion defect in the AMF — it never relays the reject to the UE, so this cause
value is currently unobservable in a live network. That is being fixed separately in
`omec-project/amf`; this change should land first or together with it, never after, so no UE
ever receives cause 91.

Verified with `go test -race ./... -count=1`, `staticcheck ./...` and
`golangci-lint run` (v2.11.3) — all clean. `context/db_uptunnel.go` is reported by `gofumpt`
on `main` already and is untouched here.
