### PR TITLE
pfcp, producer: answer the AMF's failure notification, and every session report

### DIFF
--- a/context/remote_seid_test.go
+++ b/context/remote_seid_test.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import "testing"
+
+// A PFCP message carries the SEID assigned by whoever receives it, so a report arriving
+// under this element's SEID has to be answered under the user plane's.
+func TestRemoteSEIDByLocalSEID(t *testing.T) {
+	smContext := &SMContext{
+		PFCPContext: map[string]*PFCPSessionContext{
+			"192.168.252.3": {LocalSEID: 11, RemoteSEID: 0xAA},
+			"192.168.252.4": {LocalSEID: 12, RemoteSEID: 0xBB},
+		},
+	}
+
+	if got, found := smContext.RemoteSEIDByLocalSEID(12); !found || got != 0xBB {
+		t.Errorf("RemoteSEIDByLocalSEID(12) = (%#x, %t), want (0xbb, true)", got, found)
+	}
+
+	// Not found must be distinguishable, so the caller can fall back to echoing rather
+	// than answering under a zero SEID.
+	if got, found := smContext.RemoteSEIDByLocalSEID(99); found || got != 0 {
+		t.Errorf("RemoteSEIDByLocalSEID(99) = (%#x, %t), want (0, false)", got, found)
+	}
+}

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -503,6 +503,24 @@ func (smContext *SMContext) GetNodeIDByLocalSEID(seid uint64) (nodeID NodeID) {
 	return
 }
 
+// RemoteSEIDByLocalSEID returns the SEID the user-plane function assigned to the session
+// this element knows by seid.
+//
+// A PFCP message carries the SEID assigned by whoever receives it, so a request the UPF
+// sends arrives under this element's own SEID and the response to it has to go back under
+// the UPF's. Echoing the request's value instead -- which is what this element did, with a
+// TODO admitting it -- is inert only for as long as no cause is sent that makes the peer
+// read the field.
+func (smContext *SMContext) RemoteSEIDByLocalSEID(seid uint64) (uint64, bool) {
+	for _, pfcpCtx := range smContext.PFCPContext {
+		if pfcpCtx.LocalSEID == seid {
+			return pfcpCtx.RemoteSEID, true
+		}
+	}
+
+	return 0, false
+}
+
 func (smContext *SMContext) AllocateLocalSEIDForDataPath(dataPath *DataPath) {
 	logger.PduSessLog.Debugln("in AllocateLocalSEIDForDataPath")
 	for curDataPathNode := dataPath.FirstDPNode; curDataPathNode != nil; curDataPathNode = curDataPathNode.Next() {

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -698,94 +698,105 @@ func HandlePfcpSessionReportRequest(msg *udp.Message) {
 	smContext.SMLock.Lock()
 	defer smContext.SMLock.Unlock()
 
-	if smContext.UpCnxState == models.UPCNXSTATE_DEACTIVATED {
-		if req.ReportType.HasDLDR() {
-			downlinkServiceInfo, err := req.DownlinkDataReport.DownlinkDataServiceInformation()
-			if err != nil {
-				logger.PfcpLog.Warnln("DownlinkDataServiceInformation not found in DownlinkDataReport")
-			}
-
-			if downlinkServiceInfo != nil {
-				smContext.SubPfcpLog.Warnln("PFCP Session Report Request DownlinkDataServiceInformation handling is not implemented")
-			}
-
-			n1n2Request := models.NewN1N2MessageTransferRequest()
-			defer util.CleanupMultipartTempFiles(n1n2Request)
-			cause = ie.CauseRequestRejected
-			pfcpSRflag.Drobu = true
-
-			// TS 23.502 4.2.3.3 3a. Send Namf_Communication_N1N2MessageTransfer Request, SMF->AMF
-			n2SmBuf, err := smf_context.BuildPDUSessionResourceSetupRequestTransfer(smContext)
-			if err != nil {
-				smContext.SubPduSessLog.Errorln("build PDU Session Resource Setup Request Transfer failed:", err)
-			} else {
-				tmpFile, fileErr := util.CreatePayloadTempFile(n2SmBuf)
-				if fileErr != nil {
-					smContext.SubPduSessLog.Errorf("failed to create temp file: %v", fileErr)
-				} else {
-					n1n2Request.SetBinaryDataN2Information(tmpFile)
-				}
-			}
-
-			if n1n2Request.GetBinaryDataN2Information() != nil {
-				// n1n2FailureTxfNotifURI to be added in n1n2 request transfer.
-				// It is used as path by AMF to send failure notification message towards SMF
-				n1n2FailureTxfNotifURI := "/nsmf-callback/sm-n1n2failnotify/"
-				n1n2FailureTxfNotifURI += smContext.Ref
-
-				n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
-				n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_SETUP_REQ)
-				smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
-				smInfo.SetN2InfoContent(*n2InfoContent)
-				if smContext.Snssai != nil {
-					smInfo.SetSNssai(*smContext.Snssai)
-				}
-				n2InfoContainer := models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM)
-				n2InfoContainer.SetSmInfo(*smInfo)
-
-				// Temporarily assign SMF itself, TODO: TS 23.502 4.2.3.3 5. Namf_Communication_N1N2TransferFailureNotification
-				jsonData := models.NewN1N2MessageTransferReqData()
-				jsonData.SetPduSessionId(smContext.PDUSessionID)
-				jsonData.SetSkipInd(false)
-				jsonData.SetN1n2FailureTxfNotifURI(fmt.Sprintf("%s://%s:%d%s",
-					smf_context.SMF_Self().URIScheme,
-					smf_context.SMF_Self().RegisterIPv4,
-					smf_context.SMF_Self().SBIPort,
-					n1n2FailureTxfNotifURI))
-				jsonData.SetN2InfoContainer(*n2InfoContainer)
-				n1n2Request.SetJsonData(*jsonData)
-
-				rspData, n1n2Err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
-				if n1n2Err != nil {
-					smContext.SubPfcpLog.Warnf("send N1N2Transfer failed: %v", n1n2Err)
-				}
-				if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE {
-					smContext.SubPfcpLog.Infof("receive %v, AMF is able to page the UE", rspData.GetCause())
-
-					pfcpSRflag.Drobu = false
-					cause = ie.CauseRequestAccepted
-				}
-				if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_UE_NOT_RESPONDING {
-					smContext.SubPfcpLog.Infof("receive %v, UE is not responding to N1N2 transfer message", rspData.GetCause())
-					// TODO: TS 23.502 4.2.3.3 3c. Failure indication
-				}
-			} else {
-				smContext.SubPfcpLog.Warnln("skipping N1N2 transfer because N2 SM information is unavailable")
-			}
-
-			// Sending Session Report Response to UPF.
-			smContext.SubPfcpLog.Infof("sending Session Report to UPF with Cause %v", cause)
-			err = pfcp_message.SendPfcpSessionReportResponse(msg.RemoteAddr, cause, pfcpSRflag, seqFromUPF, SEID)
-			if err != nil {
-				logger.PfcpLog.Errorf("failed to send PFCP Session Report Response: %+v", err)
-			}
-		}
+	// Answer under the SEID the user plane assigned, not the one it addressed us by.
+	// See SMContext.RemoteSEIDByLocalSEID. The no-context branch above cannot do this --
+	// with no context there is nothing to look the value up in -- so it still echoes.
+	responseSEID := SEID
+	if remoteSEID, found := smContext.RemoteSEIDByLocalSEID(SEID); found {
+		responseSEID = remoteSEID
+	} else {
+		smContext.SubPfcpLog.Warnf("no PFCP context for local SEID[%d], answering the report under it", SEID)
 	}
 
-	// TS 23.502 4.2.3.3 2b. Send Data Notification Ack, SMF->UPF
-	//	cause.CauseValue = ie.CauseRequestAccepted
-	// TODO fix: SEID should be the value sent by UPF but now the SEID value is from sm context
-	// pfcp_message.SendPfcpSessionReportResponse(msg.RemoteAddr, cause, seqFromUPF, SEID)
+	// Default to a rejection carrying DROBU: any path that cannot act on this report
+	// still answers it. TS 29.244 expects a response to every request, and silence left
+	// the UPF retransmitting into nothing while holding traffic it should have released.
+	cause = ie.CauseRequestRejected
+	pfcpSRflag.Drobu = true
+
+	if smContext.UpCnxState == models.UPCNXSTATE_DEACTIVATED && req.ReportType.HasDLDR() {
+		downlinkServiceInfo, err := req.DownlinkDataReport.DownlinkDataServiceInformation()
+		if err != nil {
+			logger.PfcpLog.Warnln("DownlinkDataServiceInformation not found in DownlinkDataReport")
+		}
+
+		if downlinkServiceInfo != nil {
+			smContext.SubPfcpLog.Warnln("PFCP Session Report Request DownlinkDataServiceInformation handling is not implemented")
+		}
+
+		n1n2Request := models.NewN1N2MessageTransferRequest()
+		defer util.CleanupMultipartTempFiles(n1n2Request)
+
+		// TS 23.502 4.2.3.3 3a. Send Namf_Communication_N1N2MessageTransfer Request, SMF->AMF
+		n2SmBuf, err := smf_context.BuildPDUSessionResourceSetupRequestTransfer(smContext)
+		if err != nil {
+			smContext.SubPduSessLog.Errorln("build PDU Session Resource Setup Request Transfer failed:", err)
+		} else {
+			tmpFile, fileErr := util.CreatePayloadTempFile(n2SmBuf)
+			if fileErr != nil {
+				smContext.SubPduSessLog.Errorf("failed to create temp file: %v", fileErr)
+			} else {
+				n1n2Request.SetBinaryDataN2Information(tmpFile)
+			}
+		}
+
+		if n1n2Request.GetBinaryDataN2Information() != nil {
+			// n1n2FailureTxfNotifURI to be added in n1n2 request transfer.
+			// It is used as path by AMF to send failure notification message towards SMF
+			n1n2FailureTxfNotifURI := "/nsmf-callback/sm-n1n2failnotify/"
+			n1n2FailureTxfNotifURI += smContext.Ref
+
+			n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
+			n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_SETUP_REQ)
+			smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
+			smInfo.SetN2InfoContent(*n2InfoContent)
+			if smContext.Snssai != nil {
+				smInfo.SetSNssai(*smContext.Snssai)
+			}
+			n2InfoContainer := models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM)
+			n2InfoContainer.SetSmInfo(*smInfo)
+
+			// Temporarily assign SMF itself, TODO: TS 23.502 4.2.3.3 5. Namf_Communication_N1N2TransferFailureNotification
+			jsonData := models.NewN1N2MessageTransferReqData()
+			jsonData.SetPduSessionId(smContext.PDUSessionID)
+			jsonData.SetSkipInd(false)
+			jsonData.SetN1n2FailureTxfNotifURI(fmt.Sprintf("%s://%s:%d%s",
+				smf_context.SMF_Self().URIScheme,
+				smf_context.SMF_Self().RegisterIPv4,
+				smf_context.SMF_Self().SBIPort,
+				n1n2FailureTxfNotifURI))
+			jsonData.SetN2InfoContainer(*n2InfoContainer)
+			n1n2Request.SetJsonData(*jsonData)
+
+			rspData, n1n2Err := consumer.SendN1N2TransferWithRediscovery(context.Background(), smContext, n1n2Request)
+			if n1n2Err != nil {
+				smContext.SubPfcpLog.Warnf("send N1N2Transfer failed: %v", n1n2Err)
+			}
+			if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_ATTEMPTING_TO_REACH_UE {
+				smContext.SubPfcpLog.Infof("receive %v, AMF is able to page the UE", rspData.GetCause())
+
+				pfcpSRflag.Drobu = false
+				cause = ie.CauseRequestAccepted
+			}
+			if n1n2Err == nil && rspData != nil && rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_UE_NOT_RESPONDING {
+				smContext.SubPfcpLog.Infof("receive %v, UE is not responding to N1N2 transfer message", rspData.GetCause())
+				// TODO: TS 23.502 4.2.3.3 3c. Failure indication
+			}
+		} else {
+			smContext.SubPfcpLog.Warnln("skipping N1N2 transfer because N2 SM information is unavailable")
+		}
+	} else {
+		smContext.SubPfcpLog.Warnf("session report not actionable: UP connection state %v, report type %v",
+			smContext.UpCnxState, req.ReportType)
+	}
+
+	// TS 23.502 4.2.3.3 2b. Data Notification Ack, SMF->UPF. Sent on every path: the
+	// cause says whether the report was acted on, and a peer can interpret a cause.
+	smContext.SubPfcpLog.Infof("sending Session Report to UPF with Cause %v", cause)
+
+	if err := pfcp_message.SendPfcpSessionReportResponse(msg.RemoteAddr, cause, pfcpSRflag, seqFromUPF, responseSEID); err != nil {
+		logger.PfcpLog.Errorf("failed to send PFCP Session Report Response: %+v", err)
+	}
 }
 
 func HandlePfcpSessionReportResponse(msg *udp.Message) {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -874,13 +874,17 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 
 	var httpResponse *httpwrapper.Response
 
+	// Set only once a modification is actually on its way to the UPF: every path that
+	// does not send one must answer the notification instead of waiting for a response
+	// that cannot come.
+	awaitingModification := false
+
 	pdrList := []*smf_context.PDR{}
 	farList := []*smf_context.FAR{}
 	qerList := []*smf_context.QER{}
 	barList := []*smf_context.BAR{}
 
 	if smContext.Tunnel != nil {
-		smContext.PendingUPF = make(smf_context.PendingUPF)
 		for _, dataPath := range smContext.Tunnel.DataPathPool {
 			ANUPF := dataPath.FirstDPNode
 			for _, DLPDR := range ANUPF.DownLinkTunnel.PDR {
@@ -890,7 +894,6 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 				} else {
 					DLPDR.FAR.ApplyAction = smf_context.ApplyAction{Buff: false, Drop: true, Dupl: false, Forw: false, Nocp: false}
 					DLPDR.FAR.State = smf_context.RULE_UPDATE
-					smContext.PendingUPF[ANUPF.GetNodeIP()] = true
 					farList = append(farList, DLPDR.FAR)
 				}
 			}
@@ -899,11 +902,46 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 		defaultPath := smContext.Tunnel.DataPathPool.GetDefaultPath()
 		ANUPF := defaultPath.FirstDPNode
 
+		// Await only the UPF this actually sends to. Marking one entry per data path
+		// while sending a single modification means the response handlers -- which
+		// signal only once PendingUPF is empty -- never signal for a session with more
+		// than one path, and the wait below does not end. The rules of the other paths
+		// are still in farList, as they were before: that they go to one UPF is a
+		// separate defect, and pretending to await answers that were never asked for
+		// does not fix it.
+		smContext.PendingUPF = make(smf_context.PendingUPF)
+		smContext.PendingUPF[ANUPF.GetNodeIP()] = true
+
+		// The response handler only signals SBIPFCPCommunicationChan while the context
+		// is in this state. Without the transition the modification was answered, the
+		// signal was never sent, and the wait below never ended.
+		stateBeforeModify := smContext.SMContextState
+		smContext.ChangeState(smf_context.SmStatePfcpModify)
+
 		// Sending PFCP modification with flag set to DROP the packets.
 		err := pfcp_message.SendPfcpSessionModificationRequest(ANUPF.UPF.NodeID, smContext, pdrList, farList, barList, qerList, nil, nil, nil, ANUPF.UPF.Port)
 		if err != nil {
 			smContext.SubPduSessLog.Errorf("pfcp Session Modification Request failed: %v", err)
+
+			// Nothing is in flight, so nothing will move the state on. Leaving it in
+			// PfcpModify would strand the session for every later operation that expects
+			// to find it settled.
+			smContext.ChangeState(stateBeforeModify)
+		} else {
+			awaitingModification = true
 		}
+	}
+
+	if !awaitingModification {
+		// Nothing was sent, so nothing will arrive. Waiting anyway left the AMF's
+		// notification unanswered until its client gave up after 30 s, and left a reader
+		// parked on a channel of depth one that belongs to this session: the next
+		// modification, release or activation for it would have its response consumed
+		// here and its own waiter would hang instead.
+		smContext.SubPduSessLog.Infoln("no PFCP modification was sent, answering the notification without waiting")
+		txn.Rsp = &httpwrapper.Response{Status: http.StatusNoContent}
+
+		return nil
 	}
 
 	// Listening PFCP modification response.

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -923,10 +923,7 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 		if err != nil {
 			smContext.SubPduSessLog.Errorf("pfcp Session Modification Request failed: %v", err)
 
-			// Nothing is in flight, so nothing will move the state on. Leaving it in
-			// PfcpModify would strand the session for every later operation that expects
-			// to find it settled.
-			smContext.ChangeState(stateBeforeModify)
+			abandonPendingModify(smContext, stateBeforeModify)
 		} else {
 			awaitingModification = true
 		}
@@ -950,6 +947,21 @@ func HandlePduSessN1N2TransFailInd(eventData interface{}) error {
 	httpResponse = HandlePFCPResponse(smContext, PFCPResponseStatus)
 	txn.Rsp = httpResponse
 	return nil
+}
+
+// abandonPendingModify undoes the bookkeeping for a modification that was never sent.
+//
+// Both halves matter and they have to stay together, which is why they are one function.
+// Leaving the state at PfcpModify strands the session for every later operation that expects
+// to find it settled. Leaving the pending entry is worse and less obvious: the handover path
+// merges into whatever PendingUPF already holds rather than replacing it
+// (collectHoFARsForPFCPModify in n1n2_data_handler.go), and the response handlers signal
+// SBIPFCPCommunicationChan only once the map is empty. An entry for a request that was never
+// sent is deleted by no answer, so the next operation to wait on that channel waits for good --
+// the indefinite wait this change exists to remove, reintroduced through its own failure path.
+func abandonPendingModify(smContext *smf_context.SMContext, previous smf_context.SMContextState) {
+	smContext.ChangeState(previous)
+	smContext.PendingUPF = make(smf_context.PendingUPF)
 }
 
 // Handles PFCP response depending upon response cause recevied.

--- a/producer/pdu_session_abandon_test.go
+++ b/producer/pdu_session_abandon_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	"testing"
+
+	smf_context "github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/factory"
+	"go.uber.org/zap"
+)
+
+// A modification that was never sent must leave nothing behind that waits for an answer.
+//
+// The state and the pending entry are asserted together on purpose: reverting only the state
+// leaves an entry that no response will ever delete, and since the response handlers signal
+// SBIPFCPCommunicationChan only once PendingUPF is empty, the next operation to wait on that
+// channel would hang.
+func TestAbandonPendingModifyClearsBothHalves(t *testing.T) {
+	disabled := false
+	factory.SmfConfig = factory.Config{
+		Configuration: &factory.Configuration{
+			KafkaInfo: factory.KafkaInfo{EnableKafka: &disabled},
+		},
+	}
+
+	smContext := &smf_context.SMContext{
+		PendingUPF:     smf_context.PendingUPF{"10.0.0.1": true},
+		SMContextState: smf_context.SmStatePfcpModify,
+		SubCtxLog:      zap.NewNop().Sugar(),
+	}
+
+	abandonPendingModify(smContext, smf_context.SmStateN1N2TransferPending)
+
+	if got := smContext.SMContextState; got != smf_context.SmStateN1N2TransferPending {
+		t.Errorf("state = %v, want the state from before the modification was attempted", got)
+	}
+	if !smContext.PendingUPF.IsEmpty() {
+		t.Errorf("PendingUPF = %v, want empty: nothing was sent, so nothing can answer", smContext.PendingUPF)
+	}
+}


### PR DESCRIPTION
### What this fixes

Two paths on the aborted-paging flow that never answered. Paging is aborted often enough that
both are ordinary rather than exceptional.

**1. The N1N2 transfer failure notification hung for 30 s, and left a reader behind.**

`HandlePduSessN1N2TransFailInd` sends a PFCP Session Modification and then waits on
`SBIPFCPCommunicationChan`. The modification response only signals that channel while the context
is in `SmStatePfcpModify` — and this path never entered that state. Both goroutines park, and the
AMF's POST times out:

```
AMF  callback/http.go:52   context deadline exceeded
```

The escalation is worse than the stall. That channel is per-SM-context and **buffered to one**, so
the parked reader stays live for the life of the PDU session and consumes the next PFCP response
status written for it. A later modification, release or activation then blocks instead, and its own
waiter hangs — the mirror image of this bug, on a session that looked healthy.

**2. A Session Report Request went unanswered unless it was one specific case.**

The only `SendPfcpSessionReportResponse` sat inside a check for `UPCNXSTATE_DEACTIVATED` *and* a
DLDR report type. A report in any other state, or of any other type, got no response at all. TS
29.244 expects a response to every request, and silence leaves the user plane retransmitting into
nothing while holding traffic it should either deliver or release.

### What changes

- **Enter the state the signal is gated on**, so the existing mechanism works — rather than
  deleting the wait, because the handler does need to know the modification landed. A bare timeout
  would not be safe on its own here: the channel is buffered to one, so abandoning the read leaves
  the value in the buffer for the next waiter to misread.
- **Two further hangs on the same handler** that the state fix alone does not reach: it also waited
  when it sent nothing at all, either because the session had no tunnel or because the send failed.
  Those paths answer immediately now. A failed send also restores the previous state, since nothing
  is in flight to move it on and a context left in `SmStatePfcpModify` is one every later operation
  finds unsettled.
- **`PendingUPF` marks what is actually asked.** It was marked once per data path while a single
  modification is sent, to the default path's UPF; both response handlers signal only once
  `PendingUPF` is empty, so a session with more than one data path never got its signal. (That the
  other paths' rules travel to one UPF is a separate defect, left as it was — awaiting answers
  nobody asked for does not fix it.)
- **Every session report is answered**, defaulting to a rejection carrying DROBU, with the cause
  saying whether the report was acted on.
- **Answered under the right SEID.** A PFCP message carries the SEID assigned by whoever *receives*
  it, so a report arriving under this element's SEID must be answered under the user plane's. The
  existing code echoed the request's value, with a `TODO` admitting it.

### Why the SEID change matters even though it looks inert

It is inert only while no cause is sent that makes the peer read that field — and the peer *does*
read it when told the context was not found (`handleSessionReportResponse` uses
`srres.SEID()` to find the session it must delete locally). Two half-conformant behaviours
currently cancel out, so making either side conformant on its own turns an inert defect into a
session the user plane cannot clean up. Worth fixing as a pair, and worth knowing before anyone
fixes the other half.

The no-context branch still echoes, because with no SM context there is nothing to look the value
up in.

### Testing

`linux/amd64`, in the images CI pins:

- `go test ./context/... ./pfcp/... ./producer/...` — green in `golang:1.25.0`
- `golangci-lint run` — **0 issues** in `golangci/golangci-lint:v2.11.3`

Verified on a live deployment. The SEID change is visible on the wire: the report response now
carries `0xe142c08f39b41c8f`, the same SEID this element's own modification requests use, where it
previously echoed its own `0x2ab3e6`. A downlink packet to an idle UE produces a report, `Cause 1`,
Paging on N2, and the UE's user plane back 18 ms later; and an aborted page no longer leaves a
reader parked on the session's channel.

### Note for reviewers

There is no unit test asserting that a response *was* sent, because the send is a package-level
function and intercepting it is a larger refactor than the fix. That half is covered on hardware
instead, with a PFCP capture. Say the word if you would rather have the seam introduced.
