### PR TITLE
fix(context): publish an SM context only once it is built, and read the count atomically

### DIFF
--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -209,18 +209,21 @@ func NewSMContext(identifier string, pduSessID int32) (smContext *SMContext) {
 		DNSIPv6Request: false,
 	}
 
-	// Published only once it is fully built. Anything that finds the context -- by ref, by
-	// canonical name, or by ranging the pool -- would otherwise be able to observe one whose maps
-	// and channels have not been made yet, which is a data race on every field assigned above.
+	// initialise log tags
+	smContext.initLogTags()
+
+	// Published only once it is fully built, and this is the last thing built. Anything that finds
+	// the context -- by ref, by canonical name, or by ranging the pool -- would otherwise be able
+	// to observe one whose maps, channels or loggers have not been assigned yet: a data race on
+	// every field above, and a nil dereference on the Sub*Log fields, which every handler uses
+	// before it does anything else. Publishing after the maps but before initLogTags would close
+	// the first of those and leave the second.
 	smContextPool.Store(smContext.Ref, smContext)
 	canonicalRef.Store(canonicalName(identifier, pduSessID), smContext.Ref)
 
 	// Sess Stats
 	smContextActive := incSMContextActive()
 	metrics.SetSessStats(SMF_Self().NfInstanceID, smContextActive)
-
-	// initialise log tags
-	smContext.initLogTags()
 
 	return smContext
 }

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -72,13 +72,14 @@ func init() {
 }
 
 func incSMContextActive() uint64 {
-	atomic.AddUint64(&smContextActive, 1)
-	return smContextActive
+	// The add returns the new value. Reading the variable again is a plain load racing with every
+	// other caller's atomic store, and it can return a count from a different moment than the one
+	// this call produced.
+	return atomic.AddUint64(&smContextActive, 1)
 }
 
 func decSMContextActive() uint64 {
-	atomic.AddUint64(&smContextActive, ^uint64(0))
-	return smContextActive
+	return atomic.AddUint64(&smContextActive, ^uint64(0))
 }
 
 type UeIpAddr struct {
@@ -192,8 +193,6 @@ func NewSMContext(identifier string, pduSessID int32) (smContext *SMContext) {
 	smContext = new(SMContext)
 	// Create Ref and identifier
 	smContext.Ref = uuid.New().URN()
-	smContextPool.Store(smContext.Ref, smContext)
-	canonicalRef.Store(canonicalName(identifier, pduSessID), smContext.Ref)
 
 	smContext.SMContextState = SmStateInit
 	smContext.Identifier = identifier
@@ -209,6 +208,12 @@ func NewSMContext(identifier string, pduSessID int32) (smContext *SMContext) {
 		DNSIPv4Request: false,
 		DNSIPv6Request: false,
 	}
+
+	// Published only once it is fully built. Anything that finds the context -- by ref, by
+	// canonical name, or by ranging the pool -- would otherwise be able to observe one whose maps
+	// and channels have not been made yet, which is a data race on every field assigned above.
+	smContextPool.Store(smContext.Ref, smContext)
+	canonicalRef.Store(canonicalName(identifier, pduSessID), smContext.Ref)
 
 	// Sess Stats
 	smContextActive := incSMContextActive()

--- a/context/sm_context_races_test.go
+++ b/context/sm_context_races_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/omec-project/smf/context"
+)
+
+// A context is published into the pool for anything to find. Until it is fully built, "anything"
+// includes code that reads fields the constructor has not assigned yet, which is a data race on
+// every one of them. Run this under -race: without the fix the detector reports the write in
+// NewSMContext against the read here.
+func TestCreatingSessionsConcurrentlyWithPoolReadsIsRaceFree(t *testing.T) {
+	const writers, perWriter = 4, 50
+
+	var churn sync.WaitGroup
+	for w := range writers {
+		churn.Add(1)
+		go func(w int) {
+			defer churn.Done()
+			for i := range perWriter {
+				smContext := context.NewSMContext(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
+				if smContext.PFCPContext == nil {
+					t.Errorf("a context was returned before its PFCP map was made")
+				}
+			}
+		}(w)
+	}
+
+	// Read from the pool while it is being written, the way anything holding a ref does. Without
+	// the fix, GetSMContext can return a context whose fields the constructor has not reached.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for w := range writers {
+			for i := range perWriter {
+				ref, err := context.ResolveRef(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
+				if err != nil {
+					continue // not created yet
+				}
+				if smContext := context.GetSMContext(ref); smContext != nil && smContext.PFCPContext == nil {
+					t.Errorf("a context was reachable from the pool before its PFCP map was made")
+				}
+			}
+		}
+	}()
+
+	churn.Wait()
+	<-done
+}

--- a/context/sm_context_races_test.go
+++ b/context/sm_context_races_test.go
@@ -1,20 +1,19 @@
 // SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
 // SPDX-License-Identifier: Apache-2.0
 
-package context_test
+package context
 
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
-
-	"github.com/omec-project/smf/context"
 )
 
 // A context is published into the pool for anything to find. Until it is fully built, "anything"
 // includes code that reads fields the constructor has not assigned yet, which is a data race on
-// every one of them. Run this under -race: without the fix the detector reports the write in
-// NewSMContext against the read here.
+// every one of them and a nil dereference on the loggers. Run this under -race: without the fix
+// the detector reports the writes in NewSMContext against the reads here.
 func TestCreatingSessionsConcurrentlyWithPoolReadsIsRaceFree(t *testing.T) {
 	const writers, perWriter = 4, 50
 
@@ -24,7 +23,7 @@ func TestCreatingSessionsConcurrentlyWithPoolReadsIsRaceFree(t *testing.T) {
 		go func(w int) {
 			defer churn.Done()
 			for i := range perWriter {
-				smContext := context.NewSMContext(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
+				smContext := NewSMContext(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
 				if smContext.PFCPContext == nil {
 					t.Errorf("a context was returned before its PFCP map was made")
 				}
@@ -32,24 +31,52 @@ func TestCreatingSessionsConcurrentlyWithPoolReadsIsRaceFree(t *testing.T) {
 		}(w)
 	}
 
-	// Read from the pool while it is being written, the way anything holding a ref does. Without
-	// the fix, GetSMContext can return a context whose fields the constructor has not reached.
+	// Read from the pool while it is being written, the way anything holding a ref does, and keep
+	// reading until the writers are done. A single pass would be a false negative: with 200
+	// sessions to create, the reader can finish its sweep before the writers have published
+	// anything and report success without the two ever having overlapped.
+	stop := make(chan struct{})
+	var observed atomic.Int64
+
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for w := range writers {
-			for i := range perWriter {
-				ref, err := context.ResolveRef(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
-				if err != nil {
-					continue // not created yet
-				}
-				if smContext := context.GetSMContext(ref); smContext != nil && smContext.PFCPContext == nil {
-					t.Errorf("a context was reachable from the pool before its PFCP map was made")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for w := range writers {
+				for i := range perWriter {
+					ref, err := ResolveRef(fmt.Sprintf("imsi-20893%03d%05d", w, i), int32(i%15+1))
+					if err != nil {
+						continue // not created yet
+					}
+					smContext := GetSMContext(ref)
+					if smContext == nil {
+						continue
+					}
+					observed.Add(1)
+					if smContext.PFCPContext == nil {
+						t.Errorf("a context was reachable from the pool before its PFCP map was made")
+					}
+					if smContext.SubCtxLog == nil {
+						t.Errorf("a context was reachable from the pool before its loggers were set")
+					}
 				}
 			}
 		}
 	}()
 
 	churn.Wait()
+	close(stop)
 	<-done
+
+	// Without this the test can pass having proved nothing, which is the failure mode a race probe
+	// is most likely to have: it says the detector found no race, not that the two sides ever met.
+	if observed.Load() == 0 {
+		t.Fatal("the reader never found a published context, so it never overlapped the writers")
+	}
+	t.Logf("pool reads that met a published context: %d", observed.Load())
 }


### PR DESCRIPTION
## What

Two data races in `context/sm_context.go`, both reachable from ordinary concurrent session
establishment. They are independent of each other but share a file, so they are sent together.

## 1. An SM context is published before it is built

`NewSMContext` stored the context into `smContextPool`, and its ref into `canonicalRef`, as its
second and third statements — before initialising `PFCPContext`, `SBIPFCPCommunicationChan`,
`SmPolicyUpdates`, the policy data and `ProtocolConfigurationOptions`.

From the moment of those stores the context is reachable by any other goroutine, through
`GetSMContext`, through `ResolveRef`, or by ranging the pool. Every field assigned afterwards is
therefore written while another goroutine may be reading it. A reader that arrives in that window
sees a **nil `PFCPContext` map**, a nil response channel, and uninitialised policy data.

The stores now happen once the context is complete. Nothing between the old and new position needs
the context to be findable: `SmCtxtPolicyData.Initialize` operates on the embedded struct and does
not touch the pool, and no other callee reaches it.

One visible consequence, deliberately: there is now a short window in which a context exists but
cannot be found by ref. That is the safer end of the trade — a lookup that fails is a condition
callers already handle, where a lookup that returns a half-built context is not.

## 2. The active-session count is read non-atomically

```go
func incSMContextActive() uint64 {
	atomic.AddUint64(&smContextActive, 1)
	return smContextActive          // plain load, races with every other caller's store
}
```

The add is atomic and the read is not, so the returned value can come from a different moment than
the one this call produced — and the value is passed straight to `metrics.SetSessStats`, so the
session-count metric can report a count that was never true. `decSMContextActive` had the same
shape. `atomic.AddUint64` already returns the new value.

## Testing

`context/sm_context_races_test.go` creates sessions from several goroutines while another reads them
back out of the pool by ref. Under `-race` it fails on the first race without the fix and passes
with it; verified by reverting the store back to its original position, which reproduces the
detector report.

`go build ./...`, `go test ./...` and `golangci-lint run` are clean, and `go test -race ./context/`
passes.

## Why these are separate from the work that found them

Both were found while adding a feature that ranges the session pool, which is why the first one
matters more than it looks: anything walking `smContextPool` meets half-built contexts routinely.
Neither race depends on that feature and both predate it, so they are sent on their own rather than
buried in a larger change.