### PR TITLE
Restore PDU sessions onto a UPF that has restarted

### DIFF
--- a/context/pfcp_session_context.go
+++ b/context/pfcp_session_context.go
@@ -24,10 +24,16 @@ const (
 )
 
 type PFCPSessionContext struct {
-	PDRs       map[uint16]*PDR
-	NodeID     NodeID
-	LocalSEID  uint64
+	PDRs      map[uint16]*PDR
+	NodeID    NodeID
+	LocalSEID uint64
+	// RemoteSEID is zero until the node acknowledges the session, and is set back to zero by
+	// restoration to make the next send an establishment rather than a modification. Those two
+	// cases look identical here, so ClearedByRestoration tells them apart.
 	RemoteSEID uint64
+	// ClearedByRestoration records that the zero above was written deliberately, by a restoration
+	// of a session this node once held -- not that the node has never acknowledged the session.
+	ClearedByRestoration bool
 }
 
 func (pfcpSessionContext *PFCPSessionContext) String() string {

--- a/context/restoration_test.go
+++ b/context/restoration_test.go
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package context_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/omec-project/smf/context"
+)
+
+func anchor(t *testing.T, supi string, psi int32, nodeIPs ...string) *context.SMContext {
+	t.Helper()
+	smContext := context.NewSMContext(supi, psi)
+	smContext.SMLock.Lock()
+	defer smContext.SMLock.Unlock()
+	for i, ip := range nodeIPs {
+		smContext.PFCPContext[ip] = &context.PFCPSessionContext{
+			NodeID:     *context.NewNodeID(ip),
+			LocalSEID:  uint64(1000 + i),
+			RemoteSEID: uint64(2000 + i),
+		}
+	}
+	return smContext
+}
+
+// Enumeration has to be by node, because a restart is scoped to one node and re-installing a
+// session onto a UPF that never lost anything would replace working forwarding state.
+func TestSessionsAnchoredOnReturnsOnlyThatNodesSessions(t *testing.T) {
+	here := anchor(t, "imsi-208930000000001", 1, "10.20.0.1")
+	elsewhere := anchor(t, "imsi-208930000000002", 2, "10.20.0.2")
+	both := anchor(t, "imsi-208930000000003", 3, "10.20.0.1", "10.20.0.2")
+
+	found, _, _ := context.SessionsAnchoredOn(*context.NewNodeID("10.20.0.1"))
+
+	seen := map[*context.SMContext]bool{}
+	for _, s := range found {
+		seen[s] = true
+	}
+	if !seen[here] {
+		t.Errorf("the session anchored on 10.20.0.1 was not returned")
+	}
+	if !seen[both] {
+		t.Errorf("the session anchored on both nodes was not returned for 10.20.0.1")
+	}
+	if seen[elsewhere] {
+		t.Errorf("a session anchored only on 10.20.0.2 was returned for 10.20.0.1; restoring it would " +
+			"re-install rules on a node that never restarted")
+	}
+}
+
+// A node nothing is anchored on must produce an empty result rather than everything.
+func TestSessionsAnchoredOnAnUnknownNodeIsEmpty(t *testing.T) {
+	anchor(t, "imsi-208930000000004", 4, "10.20.0.3")
+
+	if found, _, _ := context.SessionsAnchoredOn(*context.NewNodeID("10.20.0.99")); len(found) != 0 {
+		t.Errorf("expected no sessions for a node holding none, got %d", len(found))
+	}
+}
+
+// Enumeration ranges the live session pool while sessions are being created, because there is no
+// index from a node to the sessions anchored on it. It must tolerate the pool changing under it
+// rather than requiring it to be still, and it must not race with the establishment that adds a
+// session's PFCP context.
+//
+// Release churn is not exercised here: ChangeState publishes through infrastructure a unit test does
+// not have. The race that matters for enumeration is against establishment, which is what adds the
+// entry this reads.
+func TestSessionsAnchoredOnToleratesConcurrentEstablishment(t *testing.T) {
+	node := *context.NewNodeID("10.20.0.40")
+
+	// Bounded on both sides. Sessions are never removed from the pool, so unbounded churn makes each
+	// enumeration range an ever-larger set and the test becomes quadratic rather than informative.
+	const writers, perWriter, sweeps = 3, 60, 40
+
+	var churn sync.WaitGroup
+	for w := range writers {
+		churn.Add(1)
+		go func(w int) {
+			defer churn.Done()
+			for i := range perWriter {
+				anchor(t, fmt.Sprintf("imsi-2089300%02d%05d", w, 8000+i), int32(i%15+1), "10.20.0.40")
+			}
+		}(w)
+	}
+
+	for range sweeps {
+		for _, s := range mustAnchored(node) {
+			if s == nil {
+				t.Errorf("enumeration returned a nil session")
+				break
+			}
+		}
+	}
+	churn.Wait()
+
+	// Everything the writers created is anchored on the node, so the final sweep must see them all.
+	if got := len(mustAnchored(node)); got < writers*perWriter {
+		t.Errorf("after the churn settled, enumeration found %d session(s), want at least %d",
+			got, writers*perWriter)
+	}
+}
+
+// A UE that establishes the same PDU session again without the old one being released leaves the
+// first context in the pool describing a session nothing will use. Restoring it after a user-plane
+// restart programs the recovered node with a rule for a UE address that is gone, and spends the
+// restoration on a session that cannot carry traffic — while the live one goes unrestored. Observed
+// exactly that on a cluster.
+func TestSessionsAnchoredOnSkipsASupersededSession(t *testing.T) {
+	node := *context.NewNodeID("10.20.0.50")
+	const supi, psi = "imsi-208930000009001", int32(1)
+
+	superseded := anchor(t, supi, psi, "10.20.0.50")
+	current := anchor(t, supi, psi, "10.20.0.50") // same subscriber and session: repoints the ref
+
+	found, _, _ := context.SessionsAnchoredOn(node)
+
+	seen := map[*context.SMContext]bool{}
+	for _, s := range found {
+		seen[s] = true
+	}
+	if seen[superseded] {
+		t.Errorf("a superseded session was returned; restoring it installs a rule for a UE address " +
+			"that is gone and consumes the restoration the live session needed")
+	}
+	if !seen[current] {
+		t.Errorf("the current session was not returned, so the live session would go unrestored")
+	}
+}
+
+func mustAnchored(node context.NodeID) []*context.SMContext {
+	anchored, _, _ := context.SessionsAnchoredOn(node)
+	return anchored
+}
+
+// A session whose establishment is still outstanding must be left alone. Restoring it overwrites
+// the establishment in flight: on a cluster this pinned the UE address to the SMF's placeholder
+// before the UPF had chosen one, and the subscriber came up outside the address pool with no
+// downlink.
+func TestSessionsAnchoredOnSkipsASessionTheNodeHasNotAcknowledged(t *testing.T) {
+	node := *context.NewNodeID("10.20.0.50")
+	establishing := anchor(t, "imsi-208930000000050", 5, "10.20.0.50")
+	establishing.SMLock.Lock()
+	establishing.PFCPContext["10.20.0.50"].RemoteSEID = 0
+	establishing.SMLock.Unlock()
+
+	for _, s := range mustAnchored(node) {
+		if s == establishing {
+			t.Errorf("a session the node never acknowledged was offered for restoration; " +
+				"re-installing its rules overwrites the establishment still in flight")
+		}
+	}
+}
+
+// The zero written by restoration itself must not read as "never established", or a node that
+// restarts twice in quick succession leaves every session it was repairing behind on the second
+// sweep -- exactly the sessions that most need repairing.
+func TestSessionsAnchoredOnStillReturnsASessionRestorationCleared(t *testing.T) {
+	node := *context.NewNodeID("10.20.0.51")
+	interrupted := anchor(t, "imsi-208930000000051", 6, "10.20.0.51")
+	interrupted.SMLock.Lock()
+	interrupted.PFCPContext["10.20.0.51"].RemoteSEID = 0
+	interrupted.PFCPContext["10.20.0.51"].ClearedByRestoration = true
+	interrupted.SMLock.Unlock()
+
+	found := false
+	for _, s := range mustAnchored(node) {
+		if s == interrupted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a session whose remote identifier a previous restoration cleared was not offered " +
+			"to the restart that superseded it; it would be left unrepaired")
+	}
+}

--- a/context/sm_context.go
+++ b/context/sm_context.go
@@ -296,6 +296,125 @@ func GetSMContext(ref string) (smContext *SMContext) {
 	return
 }
 
+// SessionsAnchoredOn returns the SM contexts that hold a PFCP session on the given node.
+//
+// There is no index from a user-plane node to the sessions anchored on it, so this ranges the
+// pool. The PFCP context of each session is keyed by the node's address, which is the same key
+// the session establishment path uses, so membership is a lookup rather than a walk of the data
+// path.
+//
+// The result is a snapshot. Sessions established after it are already correct on a node that has
+// just restarted and must not be re-installed, and sessions released after it must not be
+// resurrected — so callers work from the list as taken and re-check liveness before acting on any
+// entry.
+// The second return names the sessions that could not be examined, rather than counting them.
+//
+// A session whose lock could not be taken cannot have its PFCPContext read, so there is no way to
+// tell whether it is anchored on this node or on another one -- and counting it against this node
+// makes a UPF with nothing on it report sessions it does not have. The references are returned so
+// the caller can decide which of them it has previously seen on this node; Ref is assigned before
+// the context is published to the pool and never changes, so reading it without the lock is safe.
+// The third return counts sessions anchored here whose first establishment is still outstanding.
+// They are excluded from restoration deliberately -- reissuing over an establishment in flight
+// overwrites it -- but a caller that sees no anchored sessions must not conclude the node is empty
+// when this is non-zero.
+func SessionsAnchoredOn(nodeID NodeID) (anchoredSessions []*SMContext, couldNotExamine []string, stillEstablishing int) {
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+
+	anchored := make([]*SMContext, 0)
+	unexaminable := make([]string, 0)
+	scanned, superseded, establishing := 0, 0, 0
+	otherKeys := make(map[string]int)
+	smContextPool.Range(func(_, value any) bool {
+		smContext, ok := value.(*SMContext)
+		if !ok || smContext == nil {
+			return true
+		}
+		scanned++
+
+		// TryLock, never Lock. This ranges every session in the pool, so blocking on one session's
+		// lock makes a global sweep wait on a single session's procedure. The codebase holds SMLock
+		// across network calls -- the N1N2 transfer to the AMF, among others -- so that wait is
+		// unbounded, and a sweep stuck behind it never returns. Observed on a cluster: one session
+		// held the lock and every subsequent restoration for that UPF stopped before its first log
+		// line.
+		//
+		// Skipping a session whose lock is held is the right answer rather than a concession. A
+		// session mid-procedure is being established, modified or torn down, and none of those is a
+		// session the restarted node was holding.
+		if !smContext.SMLock.TryLock() {
+			unexaminable = append(unexaminable, smContext.Ref)
+			return true
+		}
+		pfcpContext, onThisNode := smContext.PFCPContext[nodeIP]
+		// A session the node has never acknowledged is not a session it was holding. The entry is
+		// created when the rules are allocated and RemoteSEID is filled in only when the
+		// establishment response arrives, so a zero that restoration did not write means an
+		// establishment is still outstanding: a session being set up alongside the restart rather
+		// than one lost to it.
+		//
+		// Restoring one overwrites the establishment in flight. Seen on a cluster, three
+		// milliseconds either side of the race: the UE address was pinned to the SMF's placeholder
+		// before the UPF had chosen one, and the subscriber came up on an address outside the pool
+		// with no downlink -- a worse outcome than the stall this change exists to fix.
+		neverAcknowledged := onThisNode && pfcpContext.RemoteSEID == 0 && !pfcpContext.ClearedByRestoration
+		identifier, pduSessionID, ref := smContext.Identifier, smContext.PDUSessionID, smContext.Ref
+		if !onThisNode {
+			for key := range smContext.PFCPContext {
+				otherKeys[key]++
+			}
+		}
+		smContext.SMLock.Unlock()
+
+		if !onThisNode {
+			return true
+		}
+		if neverAcknowledged {
+			establishing++
+			return true
+		}
+		if !isCurrent(identifier, pduSessionID, ref) {
+			superseded++
+			return true
+		}
+		anchored = append(anchored, smContext)
+		return true
+	})
+
+	// Logged unconditionally. A sweep that reports only when it skipped something is silent in the
+	// case that matters most -- finding nothing at all -- and that silence cost a diagnosis round:
+	// "no sessions anchored" with no way to tell an empty pool from a mis-keyed lookup.
+	logger.CtxLog.Infof("sessions anchored on %s: %d of %d scanned (%d could not be examined and may be "+
+		"on any node, %d superseded by a later session for the same subscriber, %d still being established)",
+		nodeIP, len(anchored), scanned, len(unexaminable), superseded, establishing)
+	if len(anchored) == 0 && len(otherKeys) > 0 {
+		// Separates an empty pool from a lookup that did not match: if sessions are anchored under
+		// some other key, the node identity resolved differently here than when they were created.
+		logger.CtxLog.Warnf("no session matched %s, but the pool holds sessions anchored under %v",
+			nodeIP, otherKeys)
+	}
+	return anchored, unexaminable, establishing
+}
+
+// isCurrent reports whether this context is still the one the subscriber's PDU session resolves to.
+//
+// A context is superseded rather than released when a UE establishes the same PDU session again
+// without the old one being torn down -- a simulator restarted, a UE that re-attached after losing
+// the network. The canonical reference for that subscriber and session identifier is repointed at
+// the new context, and the old one stays in the pool describing a session nothing will ever use.
+//
+// Restoring one is worse than skipping it. It programs the recovered user plane with a rule for a UE
+// address that is gone, and it spends restoration effort the live session needed. Observed on a
+// cluster: the rule installed after a restart named a UE address two sessions out of date, while the
+// live session was never restored.
+func isCurrent(identifier string, pduSessionID int32, ref string) bool {
+	current, err := ResolveRef(identifier, pduSessionID)
+	if err != nil {
+		return false
+	}
+	return current == ref
+}
+
 // *** add unit test ***//
 func RemoveSMContext(ref string) {
 	var smContext *SMContext

--- a/context/upf.go
+++ b/context/upf.go
@@ -243,6 +243,54 @@ func NewUPF(nodeID *NodeID, ifaces []factory.InterfaceUpfInfoItem) (upf *UPF) {
 	return upf
 }
 
+// OnRestart is called when a UPF is observed to have restarted, with the node identity and the
+// recovery state that was observed.
+//
+// It is a hook rather than a direct call because the restoration lives in the producer package,
+// which reaches the PFCP adapter through pfcp/message; the adapter calling producer directly would
+// close that cycle. Both the native and the adapter datapath set it through this one variable so
+// that a restart is acted on the same way whichever of the two is in use.
+//
+// The recovery state is passed because several exchanges can carry the same restart -- a liveness
+// response and the re-association that follows it, seconds apart. It is what tells one restart from
+// the next; without it, a second observation cannot be distinguished from a node that has restarted
+// twice, and the two restorations displace each other.
+var OnRestart func(nodeID NodeID, recovery time.Time)
+
+// HasRestarted reports whether a recovery timestamp just received differs from the one already held
+// for this UPF, which is the only evidence that the UPF lost its state.
+//
+// A UPF that has merely stopped answering — a liveness timeout, an exhausted retry count, a
+// transition to NotAssociated — still holds every rule installed on it. Treating that as a restart
+// would re-install sessions over forwarding state that is working. A zero held value means this SMF
+// has not seen the UPF before, which is a first association rather than a restart.
+//
+// Compared at second granularity, and with Unix rather than !=. A PFCP recovery timestamp carries
+// whole seconds since the epoch and nothing finer, so anything below a second is not information
+// the peer sent. Comparing time.Time values with != also compares their monotonic reading and
+// location, which makes two timestamps describing the same second differ for reasons that have
+// nothing to do with the UPF.
+//
+// Which sites are restart evidence, and which are not, as of this change:
+//
+//	restart evidence -- a received recovery timestamp, compared before the held value is replaced
+//	  pfcp/handler/handler.go   heartbeat response, association setup request, association setup response
+//	  pfcp/adapter/adapter.go   heartbeat response, association setup response
+//
+//	NOT restart evidence -- the peer stopped answering, or this is a first association
+//	  pfcp/handler/handler.go   UPFStatus = NotAssociated on a heartbeat with no known UPF
+//	  pfcp/adapter/adapter.go   UPFStatus = NotAssociated on heartbeat failure
+//	  context/upf.go            UPFStatus = NotAssociated at construction
+//
+// Wiring restoration to the second group would re-install sessions on a node that never lost them.
+func (upf *UPF) HasRestarted(received time.Time) bool {
+	held := upf.RecoveryTimeStamp.RecoveryTimeStamp
+	if held.IsZero() {
+		return false
+	}
+	return received.Unix() != held.Unix()
+}
+
 // *** add unit test ***//
 // GetInterface return the UPFInterfaceInfo that match input cond
 func (upf *UPF) GetInterface(interfaceType models.UPInterfaceType, dnn string) *UPFInterfaceInfo {

--- a/metrics/restoration_test.go
+++ b/metrics/restoration_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func labelsOf(t *testing.T, c prometheus.Collector) map[string]bool {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 16)
+	c.Collect(ch)
+	close(ch)
+	seen := map[string]bool{}
+	for m := range ch {
+		var pb dto.Metric
+		if err := m.Write(&pb); err != nil {
+			t.Fatalf("writing metric: %v", err)
+		}
+		for _, l := range pb.GetLabel() {
+			seen[l.GetName()] = true
+		}
+	}
+	return seen
+}
+
+// A metrics endpoint is readable by anything that can reach the pod. A per-session label would put
+// a subscriber identity there, which is the one thing these counters must not carry.
+func TestRestorationMetricsCarryNoSubscriberIdentity(t *testing.T) {
+	smfStats = initSmfStats()
+	AddUpfRestorationStats("smf-1", "10.0.0.1", "restored", 3)
+	SetUpfUnrestoredSessions("smf-1", "10.0.0.1", 2)
+
+	forbidden := []string{"supi", "imsi", "pei", "gpsi", "msisdn", "ue", "session_id", "seid", "ip"}
+	for _, c := range []prometheus.Collector{smfStats.upfRestoration, smfStats.upfUnrestored} {
+		for label := range labelsOf(t, c) {
+			for _, bad := range forbidden {
+				if strings.Contains(strings.ToLower(label), bad) {
+					t.Errorf("label %q looks like a subscriber identifier", label)
+				}
+			}
+		}
+	}
+}
+
+// A restoration that restored some sessions and released the rest must not be readable as one that
+// simply completed. That conflation is the failure this change exists to remove.
+func TestAPartialRestorationIsDistinguishableFromAFullOne(t *testing.T) {
+	smfStats = initSmfStats()
+
+	AddUpfRestorationStats("smf-1", "10.0.0.7", "restored", 5)
+	SetUpfUnrestoredSessions("smf-1", "10.0.0.7", 0)
+	full := gaugeValue(t, smfStats.upfUnrestored, "smf-1", "10.0.0.7")
+
+	AddUpfRestorationStats("smf-1", "10.0.0.8", "restored", 3)
+	AddUpfRestorationStats("smf-1", "10.0.0.8", "released", 2)
+	SetUpfUnrestoredSessions("smf-1", "10.0.0.8", 2)
+	partial := gaugeValue(t, smfStats.upfUnrestored, "smf-1", "10.0.0.8")
+
+	if full != 0 {
+		t.Errorf("a UPF whose sessions all came back reports %v outstanding, want 0", full)
+	}
+	if partial == full {
+		t.Errorf("a UPF with sessions left behind is indistinguishable from a fully recovered one "+
+			"(%v vs %v); an operator would read a partially dead UPF as healthy", partial, full)
+	}
+}
+
+func gaugeValue(t *testing.T, g *prometheus.GaugeVec, labels ...string) float64 {
+	t.Helper()
+	var pb dto.Metric
+	if err := g.WithLabelValues(labels...).Write(&pb); err != nil {
+		t.Fatalf("reading gauge: %v", err)
+	}
+	return pb.GetGauge().GetValue()
+}

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -26,6 +26,20 @@ type SmfStats struct {
 	svcUdmMsg   *prometheus.CounterVec
 	sessions    *prometheus.GaugeVec
 	sessProfile *prometheus.GaugeVec
+
+	// upfRestoration counts what happened to each session after a UPF restarted, and
+	// upfUnrestored is how many of that UPF's sessions are currently not carrying traffic.
+	//
+	// These exist because the failure they describe is silent by construction. Before this,
+	// every signal an operator could read reported health after a UPF restart: the association
+	// reached its established state, heartbeats continued, and no error was logged, while every
+	// session on that UPF forwarded nothing. A restoration that partially succeeds reproduces
+	// exactly that ambiguity unless its outcome is counted.
+	//
+	// Labelled by UPF, never by subscriber. A per-session label here would put a SUPI in a
+	// metrics endpoint.
+	upfRestoration *prometheus.CounterVec
+	upfUnrestored  *prometheus.GaugeVec
 }
 
 var smfStats *SmfStats
@@ -69,6 +83,16 @@ func initSmfStats() *SmfStats {
 			Name: "smf_pdu_session_profile",
 			Help: "SMF PDU session Profile",
 		}, []string{"id", "ip", "state", "upf", "enterprise"}),
+
+		upfRestoration: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "smf_upf_restoration_sessions_total",
+			Help: "Sessions handled after a UPF restart, by outcome",
+		}, []string{"id", "upf", "outcome"}),
+
+		upfUnrestored: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "smf_upf_unrestored_sessions",
+			Help: "Sessions on a UPF that are not carrying traffic after a restart",
+		}, []string{"id", "upf"}),
 	}
 }
 
@@ -92,6 +116,12 @@ func (ps *SmfStats) register() error {
 		return err
 	}
 	if err := prometheus.Register(ps.sessProfile); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.upfRestoration); err != nil {
+		return err
+	}
+	if err := prometheus.Register(ps.upfUnrestored); err != nil {
 		return err
 	}
 	return nil
@@ -147,4 +177,21 @@ func SetSessStats(nodeId string, count uint64) {
 // SetSessProfileStats maintains Session profile info
 func SetSessProfileStats(id, ip, state, upf, enterprise string, count uint64) {
 	smfStats.sessProfile.WithLabelValues(id, ip, state, upf, enterprise).Set(float64(count))
+}
+
+// AddUpfRestorationStats records the outcome for sessions handled after a UPF restart. The outcome
+// is one of "restored", "released" or "skipped": a restoration that restored some and released the
+// rest must not be reportable as simply having completed.
+func AddUpfRestorationStats(smfID, upf, outcome string, count int) {
+	if count <= 0 {
+		return
+	}
+	smfStats.upfRestoration.WithLabelValues(smfID, upf, outcome).Add(float64(count))
+}
+
+// SetUpfUnrestoredSessions records how many of a UPF's sessions are not carrying traffic. It is set
+// to zero on a restoration that leaves none behind, so a UPF that has recovered stops reporting a
+// backlog it no longer has.
+func SetUpfUnrestoredSessions(smfID, upf string, count int) {
+	smfStats.upfUnrestored.WithLabelValues(smfID, upf).Set(float64(count))
 }

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -179,9 +179,17 @@ func SetSessProfileStats(id, ip, state, upf, enterprise string, count uint64) {
 	smfStats.sessProfile.WithLabelValues(id, ip, state, upf, enterprise).Set(float64(count))
 }
 
-// AddUpfRestorationStats records the outcome for sessions handled after a UPF restart. The outcome
-// is one of "restored", "released" or "skipped": a restoration that restored some and released the
-// rest must not be reportable as simply having completed.
+// AddUpfRestorationStats records the outcome for sessions handled after a UPF restart. The counts
+// are kept apart on purpose: a restoration that restored some sessions and released the rest must
+// not be reportable as simply having completed.
+//
+// The outcome is one of five, and a dashboard should expect all of them:
+//
+//	restored     - re-installed on the node and carrying traffic again
+//	released     - torn down because the node would not accept it back
+//	skipped      - not attempted: busy, purged, or no longer live
+//	unexaminable - nothing could be learned about it, so it is not known to be healthy
+//	gone         - no longer anchored on this node when the wave reached it
 func AddUpfRestorationStats(smfID, upf, outcome string, count int) {
 	if count <= 0 {
 		return

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -47,6 +47,9 @@ var smfStats *SmfStats
 // msgCounterLabels is the shared label set for the per-interface message counters below.
 var msgCounterLabels = []string{"smf_id", "msg_type", "direction", "result", "reason"}
 
+// labelUpf is the user-plane label shared by the counters below.
+const labelUpf = "upf"
+
 func initSmfStats() *SmfStats {
 	return &SmfStats{
 		n11Msg: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -82,17 +85,17 @@ func initSmfStats() *SmfStats {
 		sessProfile: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "smf_pdu_session_profile",
 			Help: "SMF PDU session Profile",
-		}, []string{"id", "ip", "state", "upf", "enterprise"}),
+		}, []string{"id", "ip", "state", labelUpf, "enterprise"}),
 
 		upfRestoration: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "smf_upf_restoration_sessions_total",
 			Help: "Sessions handled after a UPF restart, by outcome",
-		}, []string{"id", "upf", "outcome"}),
+		}, []string{"id", labelUpf, "outcome"}),
 
 		upfUnrestored: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "smf_upf_unrestored_sessions",
 			Help: "Sessions on a UPF that are not carrying traffic after a restart",
-		}, []string{"id", "upf"}),
+		}, []string{"id", labelUpf}),
 	}
 }
 

--- a/pfcp/adapter/adapter.go
+++ b/pfcp/adapter/adapter.go
@@ -140,6 +140,16 @@ func HandlePfcpAssociationSetupResponse(msg *udp.Message) {
 			logger.PfcpLog.Errorf("pfcp association setup response RecoveryTimeStamp error: %v", err)
 			return
 		}
+		// Compared before the overwrite below, for the same reason as on the native path: once the
+		// held value has been replaced the evidence of the restart is gone, and what remains is the
+		// state that hides it.
+		if upf.HasRestarted(recoveryTimestamp) {
+			logger.PfcpLog.Warnf("PFCP Association Setup Response, upf [%v] recovery timestamp changed", upf.NodeID)
+			if context.OnRestart != nil {
+				context.OnRestart(upf.NodeID, recoveryTimestamp)
+			}
+		}
+
 		upf.RecoveryTimeStamp = context.RecoveryTimeStamp{
 			RecoveryTimeStamp: recoveryTimestamp,
 		}
@@ -184,14 +194,15 @@ func HandlePfcpHeartbeatResponse(msg *udp.Message) {
 		return
 	}
 
-	if recoveryTimestamp != upf.RecoveryTimeStamp.RecoveryTimeStamp {
+	if upf.HasRestarted(recoveryTimestamp) {
 		// change UPF state to not associated so that
 		// PFCP Association can be initiated again
 		upf.UPFStatus = context.NotAssociated
 		logger.PfcpLog.Warnf("PFCP Heartbeat Response, upf [%v] recovery timestamp changed", upf.NodeID)
 
-		// TODO: Session cleanup required and updated to AMF/PCF
-		// metrics.IncrementN4MsgStats(context.SMF_Self().NfInstanceID, pfcpmsgtypes.PfcpMsgTypeString(msg.PfcpMessage.Header.MessageType), "In", "Failure", "RecoveryTimeStamp_mismatch")
+		if context.OnRestart != nil {
+			context.OnRestart(upf.NodeID, recoveryTimestamp)
+		}
 	}
 
 	upf.NHeartBeat = 0 // reset Heartbeat attempt to 0

--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -99,13 +99,16 @@ func HandlePfcpHeartbeatResponse(msg *udp.Message) {
 		upf.RecoveryTimeStamp = smf_context.RecoveryTimeStamp{
 			RecoveryTimeStamp: rspRecoveryTimeStamp,
 		}
-	} else if rspRecoveryTimeStamp != upf.RecoveryTimeStamp.RecoveryTimeStamp {
+	} else if upf.HasRestarted(rspRecoveryTimeStamp) {
 		// change UPF state to not associated so that
 		// PFCP Association can be initiated again
 		upf.UPFStatus = smf_context.NotAssociated
 		logger.PfcpLog.Warnf("PFCP Heartbeat Response, upf [%v] recovery timestamp changed, previous [%v], new [%v] ", upf.NodeID, upf.RecoveryTimeStamp, *rsp.RecoveryTimeStamp)
 
-		// TODO: Session cleanup required and updated to AMF/PCF
+		if smf_context.OnRestart != nil {
+			smf_context.OnRestart(upf.NodeID, rspRecoveryTimeStamp)
+		}
+
 		metrics.IncrementN4MsgStats(smf_context.SMF_Self().NfInstanceID, rsp.MessageTypeName(), "In", "Failure", "RecoveryTimeStamp_mismatch")
 	}
 
@@ -188,6 +191,20 @@ func HandlePfcpAssociationSetupRequest(msg *udp.Message) {
 	upf.UpfLock.Lock()
 	defer upf.UpfLock.Unlock()
 
+	// A UPF that restarted announces itself with this message, carrying a recovery timestamp
+	// it did not have before. That is the path a crash takes, because the node is back before
+	// its absence has been noticed. Compare before the overwrite below: afterwards the
+	// evidence of the restart is gone, and what replaces it is the state that hides it — a
+	// current timestamp, a healthy-looking association, and sessions reported as active that
+	// the UPF knows nothing about.
+	if upf.HasRestarted(recoveryTimestamp) {
+		logger.PfcpLog.Warnf("PFCP Association Setup Request, upf [%v] recovery timestamp changed, previous [%v], new [%v]",
+			upf.NodeID, upf.RecoveryTimeStamp.RecoveryTimeStamp, recoveryTimestamp)
+		if smf_context.OnRestart != nil {
+			smf_context.OnRestart(upf.NodeID, recoveryTimestamp)
+		}
+	}
+
 	upf.RecoveryTimeStamp = smf_context.RecoveryTimeStamp{
 		RecoveryTimeStamp: recoveryTimestamp,
 	}
@@ -257,6 +274,18 @@ func HandlePfcpAssociationSetupResponse(msg *udp.Message) {
 			logger.PfcpLog.Errorf("failed to parse RecoveryTimeStamp: %+v", err)
 			return
 		}
+		// The other half of re-association: ProbeInactiveUpfs initiated this one for a UPF it
+		// had marked NotAssociated, and the response is where a restart becomes visible on
+		// that path. Compared before the overwrite, for the reason given in the request
+		// handler above.
+		if upf.HasRestarted(recoveryTimestamp) {
+			logger.PfcpLog.Warnf("PFCP Association Setup Response, upf [%v] recovery timestamp changed, previous [%v], new [%v]",
+				upf.NodeID, upf.RecoveryTimeStamp.RecoveryTimeStamp, recoveryTimestamp)
+			if smf_context.OnRestart != nil {
+				smf_context.OnRestart(upf.NodeID, recoveryTimestamp)
+			}
+		}
+
 		upf.RecoveryTimeStamp = smf_context.RecoveryTimeStamp{
 			RecoveryTimeStamp: recoveryTimestamp,
 		}

--- a/pfcp/handler/restoration_test.go
+++ b/pfcp/handler/restoration_test.go
@@ -1,0 +1,262 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package handler_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/factory"
+	"github.com/omec-project/smf/pfcp/handler"
+	pfcp_message "github.com/omec-project/smf/pfcp/message"
+	"github.com/omec-project/smf/pfcp/udp"
+	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+)
+
+// restartsObserved swaps the restoration hook for a recorder, so each detection path can be tested
+// for whether it actually reaches the restoration rather than merely logging.
+func restartsObserved(t *testing.T) *[]context.NodeID {
+	t.Helper()
+	previous := context.OnRestart
+	seen := make([]context.NodeID, 0)
+	context.OnRestart = func(nodeID context.NodeID, _ time.Time) { seen = append(seen, nodeID) }
+	t.Cleanup(func() { context.OnRestart = previous })
+	return &seen
+}
+
+func configured() {
+	factory.SmfConfig = factory.Config{
+		Configuration: &factory.Configuration{
+			KafkaInfo:        factory.KafkaInfo{EnableKafka: boolPointer(false)},
+			EnableUpfAdapter: false,
+		},
+	}
+}
+
+func upfHolding(nodeIP string, recovery time.Time) *context.UPF {
+	upf := context.NewUPF(context.NewNodeID(nodeIP), nil)
+	upf.UPFStatus = context.AssociatedSetUpSuccess
+	upf.RecoveryTimeStamp = context.RecoveryTimeStamp{RecoveryTimeStamp: recovery}
+	return upf
+}
+
+func at(nodeIP string) *net.UDPAddr {
+	return &net.UDPAddr{IP: net.ParseIP(nodeIP), Port: 8805}
+}
+
+// The path a crash takes: the node is back and announces itself before its absence was noticed.
+func TestAssociationSetupRequestReachesTheRestoration(t *testing.T) {
+	configured()
+	seen := restartsObserved(t)
+	nodeIP := "10.40.0.1"
+	upfHolding(nodeIP, time.Now().Add(-time.Hour))
+
+	handler.HandlePfcpAssociationSetupRequest(&udp.Message{
+		RemoteAddr: at(nodeIP),
+		PfcpMessage: message.NewAssociationSetupRequest(1,
+			ie.NewNodeID(nodeIP, "", ""), ie.NewRecoveryTimeStamp(time.Now())),
+	})
+
+	if len(*seen) != 1 {
+		t.Errorf("the association setup request path did not reach the restoration (%d call(s)); a UPF "+
+			"announcing its own return is the path a crash takes", len(*seen))
+	}
+}
+
+// The other half of re-association: this element initiated it, for a UPF it had marked unusable.
+func TestAssociationSetupResponseReachesTheRestoration(t *testing.T) {
+	configured()
+	seen := restartsObserved(t)
+	nodeIP := "10.40.0.2"
+	upfHolding(nodeIP, time.Now().Add(-time.Hour))
+	pfcp_message.InsertPfcpTxn(77, context.NewNodeID(nodeIP))
+
+	handler.HandlePfcpAssociationSetupResponse(&udp.Message{
+		RemoteAddr: at(nodeIP),
+		PfcpMessage: message.NewAssociationSetupResponse(77,
+			ie.NewCause(ie.CauseRequestAccepted), ie.NewNodeID(nodeIP, "", ""),
+			ie.NewRecoveryTimeStamp(time.Now())),
+	})
+
+	if len(*seen) != 1 {
+		t.Errorf("the association setup response path did not reach the restoration (%d call(s))", len(*seen))
+	}
+}
+
+// A UPF that stops answering and comes back unchanged still holds every rule installed on it.
+// Re-establishing its sessions would replace forwarding state that is working.
+func TestAnUnchangedRecoveryTimestampDoesNotReachTheRestoration(t *testing.T) {
+	configured()
+	seen := restartsObserved(t)
+	nodeIP := "10.40.0.3"
+	unchanged := time.Now().Add(-time.Hour)
+	upfHolding(nodeIP, unchanged)
+
+	handler.HandlePfcpAssociationSetupRequest(&udp.Message{
+		RemoteAddr: at(nodeIP),
+		PfcpMessage: message.NewAssociationSetupRequest(2,
+			ie.NewNodeID(nodeIP, "", ""), ie.NewRecoveryTimeStamp(unchanged)),
+	})
+
+	if len(*seen) != 0 {
+		t.Errorf("a UPF that did not restart reached the restoration; its sessions are intact and " +
+			"re-establishing them would replace working forwarding state")
+	}
+}
+
+// A UPF this SMF has not seen before is a first association, not a restart.
+func TestAFirstAssociationIsNotARestart(t *testing.T) {
+	configured()
+	seen := restartsObserved(t)
+	nodeIP := "10.40.0.4"
+	context.NewUPF(context.NewNodeID(nodeIP), nil) // no recovery timestamp held
+
+	handler.HandlePfcpAssociationSetupRequest(&udp.Message{
+		RemoteAddr: at(nodeIP),
+		PfcpMessage: message.NewAssociationSetupRequest(3,
+			ie.NewNodeID(nodeIP, "", ""), ie.NewRecoveryTimeStamp(time.Now())),
+	})
+
+	if len(*seen) != 0 {
+		t.Errorf("a first association was treated as a restart")
+	}
+}
+
+// Once the held value has been replaced the evidence of the restart is gone. Every path must
+// therefore compare before it overwrites, and this asserts it rather than leaving it to inspection.
+func TestEveryPathComparesBeforeItOverwritesTheHeldTimestamp(t *testing.T) {
+	configured()
+	old := time.Now().Add(-time.Hour)
+
+	for _, path := range []struct {
+		name    string
+		nodeIP  string
+		deliver func(nodeIP string, fresh time.Time)
+	}{
+		{"association setup request", "10.40.0.5", func(nodeIP string, fresh time.Time) {
+			handler.HandlePfcpAssociationSetupRequest(&udp.Message{
+				RemoteAddr: at(nodeIP),
+				PfcpMessage: message.NewAssociationSetupRequest(4,
+					ie.NewNodeID(nodeIP, "", ""), ie.NewRecoveryTimeStamp(fresh)),
+			})
+		}},
+		{"association setup response", "10.40.0.6", func(nodeIP string, fresh time.Time) {
+			pfcp_message.InsertPfcpTxn(88, context.NewNodeID(nodeIP))
+			handler.HandlePfcpAssociationSetupResponse(&udp.Message{
+				RemoteAddr: at(nodeIP),
+				PfcpMessage: message.NewAssociationSetupResponse(88,
+					ie.NewCause(ie.CauseRequestAccepted), ie.NewNodeID(nodeIP, "", ""),
+					ie.NewRecoveryTimeStamp(fresh)),
+			})
+		}},
+	} {
+		t.Run(path.name, func(t *testing.T) {
+			seen := restartsObserved(t)
+			upf := upfHolding(path.nodeIP, old)
+			fresh := time.Now()
+
+			path.deliver(path.nodeIP, fresh)
+
+			if len(*seen) != 1 {
+				t.Fatalf("the restart was not detected, so the comparison did not happen before the overwrite")
+			}
+			if upf.RecoveryTimeStamp.RecoveryTimeStamp.Unix() != fresh.Unix() {
+				t.Errorf("the held timestamp was not updated after the comparison; the next message would " +
+					"be read as another restart")
+			}
+		})
+	}
+}
+
+// After a restart the identifier the SMF holds for a session names something the UPF no longer has.
+// The establishment that restores the session returns a new one, and that is the value every later
+// message about the session must carry. Keeping the old one would address a session that does not
+// exist on the node now serving it.
+func TestRestoringASessionReplacesTheIdentifierFromBeforeTheRestart(t *testing.T) {
+	configured()
+	nodeIP := "10.41.0.1"
+	nodeID := context.NewNodeID(nodeIP)
+
+	const (
+		beforeTheRestart = uint64(0xDEAD)
+		afterTheRestart  = uint64(0xF00D)
+	)
+
+	smContext := context.NewSMContext("imsi-208930000000801", 1)
+	smContext.Tunnel = &context.UPTunnel{
+		DataPathPool: context.DataPathPool{
+			1: &context.DataPath{
+				IsDefaultPath: true,
+				FirstDPNode:   &context.DataPathNode{UPF: &context.UPF{}, UpLinkTunnel: &context.GTPTunnel{}},
+			},
+		},
+	}
+
+	// Registers the session under a local identifier and creates its PFCP context for the node,
+	// which is what the establishment response is matched against.
+	smContext.AllocateLocalSEIDForDataPath(&context.DataPath{
+		FirstDPNode: &context.DataPathNode{UPF: &context.UPF{NodeID: *nodeID}},
+	})
+	pfcpCtx, ok := smContext.PFCPContext[nodeIP]
+	if !ok {
+		t.Fatalf("no PFCP context was created for %s", nodeIP)
+	}
+	pfcpCtx.RemoteSEID = beforeTheRestart
+	pfcp_message.InsertPfcpTxn(4321, nodeID)
+
+	handler.HandlePfcpSessionEstablishmentResponse(&udp.Message{
+		RemoteAddr: at(nodeIP),
+		PfcpMessage: message.NewSessionEstablishmentResponse(0, 0, pfcpCtx.LocalSEID, 4321, 0,
+			ie.NewCause(ie.CauseRequestAccepted),
+			ie.NewNodeID(nodeIP, "", ""),
+			ie.NewFSEID(afterTheRestart, net.ParseIP(nodeIP), nil),
+		),
+	})
+
+	got := smContext.PFCPContext[nodeIP].RemoteSEID
+	if got == beforeTheRestart {
+		t.Errorf("the session still holds the identifier from before the restart (%#x); every later "+
+			"message about it would address a session the restarted UPF never created", got)
+	}
+	if got != afterTheRestart {
+		t.Errorf("the session identifier is %#x, want %#x — the value the restoration returned", got, afterTheRestart)
+	}
+}
+
+// The heartbeat path is deliberately not in the table above. It detects the restart and reaches the
+// restoration, but leaves the held timestamp for the re-association it triggers to record.
+//
+// That is not an oversight, and recording it here was tried and reverted. Recording at the first
+// observation silences every later exchange -- including the re-association that is the only thing
+// that would notice a UPF which came back after the restoration had given up waiting for it, which
+// it does after 60 s. The duplicate restoration this used to cause is prevented by identifying a
+// restart by its recovery state instead, so the second observation is recognised as the same one.
+func TestTheHeartbeatPathLeavesTheHeldTimestampForTheReassociation(t *testing.T) {
+	configured()
+	seen := restartsObserved(t)
+	nodeIP := "10.40.0.7"
+	old := time.Now().Add(-time.Hour)
+	upf := upfHolding(nodeIP, old)
+	fresh := time.Now()
+
+	pfcp_message.InsertPfcpTxn(89, context.NewNodeID(nodeIP))
+	handler.HandlePfcpHeartbeatResponse(&udp.Message{
+		RemoteAddr:  at(nodeIP),
+		PfcpMessage: message.NewHeartbeatResponse(89, ie.NewRecoveryTimeStamp(fresh)),
+	})
+
+	if len(*seen) != 1 {
+		t.Fatalf("the heartbeat did not reach the restoration; it is the exchange that usually sees a restart first")
+	}
+	if upf.RecoveryTimeStamp.RecoveryTimeStamp.Unix() != old.Unix() {
+		t.Errorf("the heartbeat recorded the new timestamp; the re-association can then no longer see " +
+			"the restart, and a UPF that comes back late is never restored")
+	}
+	if upf.UPFStatus != context.NotAssociated {
+		t.Errorf("the UPF was not marked NotAssociated, so nothing will re-associate it")
+	}
+}

--- a/producer/callback.go
+++ b/producer/callback.go
@@ -315,7 +315,7 @@ func BuildAndSendQosN1N2TransferMsg(smContext *smfContext.SMContext) error {
 	// Prepare N2 container info (NGAP message)
 	// -------------------------------
 	// N2 Container Info
-	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
+	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: n2SmInformationContentID})
 	n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_MOD_REQ)
 	smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
 	smInfo.SetN2InfoContent(*n2InfoContent)

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -36,6 +36,9 @@ const (
 	upfAssociationRetryInterval = 50 * time.Millisecond
 )
 
+// n2SmInformationContentID names the N2 SM information part of a multipart N1N2 transfer.
+const n2SmInformationContentID = "N2SmInformation"
+
 func ensureDataPathUpfAssociated(dataPath *smf_context.DataPath) error {
 	for node := dataPath.FirstDPNode; node != nil; node = node.Next() {
 		if node.UPF == nil {
@@ -771,7 +774,7 @@ func SendPduSessN1N2Transfer(smContext *smf_context.SMContext, success bool) err
 	defer util.CleanupMultipartTempFiles(n1n2Request)
 
 	// N2 Container Info
-	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
+	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: n2SmInformationContentID})
 	n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_SETUP_REQ)
 	smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
 	smInfo.SetN2InfoContent(*n2InfoContent)

--- a/producer/restoration.go
+++ b/producer/restoration.go
@@ -1,0 +1,984 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	gocontext "context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/omec-project/openapi/v2/models"
+	"github.com/omec-project/smf/consumer"
+	"github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/logger"
+	"github.com/omec-project/smf/metrics"
+	"github.com/omec-project/smf/util"
+)
+
+// maxRestorationsInFlight bounds how many session establishments are outstanding against a UPF
+// that has just restarted.
+//
+// Every session anchored on the node needs re-installing at the same moment, and the node that
+// must accept them has just started. Issuing them as fast as they can be generated points the
+// whole anchored population at a cold node, and a node that falls over under that load restarts
+// again. The bound is on requests outstanding rather than on a delay between them, so a UPF that
+// answers slowly slows the restoration down instead of receiving more of it.
+var maxRestorationsInFlight = 8
+
+// restorationSettleTimeout bounds how long one wave is waited on before the next is issued. A UPF
+// that never answers must not stall the restoration indefinitely; the sessions it did not answer
+// for are left for the failure path rather than blocking the rest.
+var restorationSettleTimeout = 10 * time.Second
+
+// restorationPollInterval is how often a wave is checked for completion while it settles.
+var restorationPollInterval = 100 * time.Millisecond
+
+// maxConsecutiveFailedWaves bounds how long a node that answers nothing is persisted with.
+var maxConsecutiveFailedWaves = 2
+
+// associationWaitTimeout bounds how long a restoration waits for the PFCP association to come back
+// before giving up. ProbeInactiveUpfs re-associates on its own cycle, so this only has to outlast
+// that.
+var associationWaitTimeout = 60 * time.Second
+
+// enumerationWindow bounds how long sweeps are repeated when every session was busy. Measured
+// against the thing being waited for: a session is locked because a procedure holds it, and those
+// resolve in seconds. The previous bound was 20 attempts at the poll interval -- two seconds -- and
+// a cluster run at 20 sessions found every one of them locked for longer than that, so the sweep
+// gave up and the whole population was left dead.
+//
+// Waiting longer costs nothing here. This path is only reached when nothing was found, so there is
+// no session being held back by the wait.
+var enumerationWindow = 30 * time.Second
+
+// lockAcquireTimeout bounds how long restoration waits for one session's lock. Long enough to ride
+// out an ordinary in-memory critical section, far short of anything that makes a network call.
+var lockAcquireTimeout = 50 * time.Millisecond
+
+func init() {
+	context.OnRestart = RestoreSessionsOnUPF
+}
+
+var restorationsInProgress sync.Map // UPF node IP -> *restorationRun
+
+// sessionsLastSeenOn remembers which sessions a completed sweep found anchored on each node.
+//
+// A sweep that cannot take a session's lock cannot read its PFCPContext, so it cannot tell whether
+// that session belongs to this node or another one. Counting every unexaminable session against the
+// node being restored makes a UPF with nothing anchored on it report sessions it does not have.
+// Intersecting with what was last seen here gives a number that can be defended.
+var sessionsLastSeenOn sync.Map // UPF node IP -> map[string]struct{} of SMContext refs
+
+func rememberAnchored(nodeIP string, anchored []*context.SMContext) {
+	refs := make(map[string]struct{}, len(anchored))
+	for _, smContext := range anchored {
+		refs[smContext.Ref] = struct{}{}
+	}
+	sessionsLastSeenOn.Store(nodeIP, refs)
+}
+
+// attributableTo counts how many of the sessions that could not be examined were last seen anchored
+// on this node. Sessions never seen here are left out: they are somebody else's problem, and naming
+// them here would be a guess.
+func attributableTo(nodeIP string, unexaminable []string) int {
+	value, ok := sessionsLastSeenOn.Load(nodeIP)
+	if !ok {
+		return 0
+	}
+	refs, ok := value.(map[string]struct{})
+	if !ok {
+		return 0
+	}
+	count := 0
+	for _, ref := range unexaminable {
+		if _, seenHere := refs[ref]; seenHere {
+			count++
+		}
+	}
+	return count
+}
+
+type restorationRun struct {
+	superseded bool
+	// The recovery state of the restart this run is repairing. It is what tells a second observation
+	// of the same restart from a node that has restarted again.
+	recovery time.Time
+	// Set when this run displaced one that had not finished. The displaced run abandons at its next
+	// checkpoint, but it can still be inside reissue holding a session's lock, and this run's sweep
+	// will then skip that session. Recorded so the sweep can say so instead of reporting a fault.
+	displacedAPriorRun bool
+	mu                 sync.Mutex
+}
+
+func (r *restorationRun) supersede() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.superseded = true
+}
+
+// sameRestartAs reports whether this run is already repairing the restart that the given recovery
+// state describes. Compared at second resolution, as HasRestarted compares it: that is the
+// resolution the timestamp is carried at on the wire.
+func (r *restorationRun) sameRestartAs(recovery time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return !r.recovery.IsZero() && r.recovery.Unix() == recovery.Unix()
+}
+
+func (r *restorationRun) isSuperseded() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.superseded
+}
+
+// RestoreSessionsOnUPF re-installs, on a user-plane function that has restarted, the sessions this
+// SMF still holds for it.
+//
+// The UPF has forgotten its rules; this SMF has not. Its record of them is therefore the
+// description of what each session needs, and re-installing from that record is the whole of the
+// repair. The identifiers are carried over unchanged: they mean something to a UPF only while it
+// holds the rules they name, and a restarted one holds none.
+//
+// Runs asynchronously. Callers detect the restart while holding the UPF lock, which the send path
+// also takes.
+func RestoreSessionsOnUPF(nodeID context.NodeID, recovery time.Time) {
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+
+	run := &restorationRun{recovery: recovery}
+	if previous, loaded := restorationsInProgress.LoadOrStore(nodeIP, run); loaded {
+		prior, ok := previous.(*restorationRun)
+		// One restart, observed twice. A liveness response and the re-association that follows it
+		// carry the same recovery state seconds apart, and both are meant to reach this function --
+		// the spec requires every exchange that can see a restart to act on it, precisely so none of
+		// them is the only one wired. What must not follow is a second restoration: it displaces the
+		// first, and at 49 sessions the two displaced each other until neither finished and the
+		// population was left part-restored.
+		//
+		// Deduplicated here rather than by recording the recovery state at the first observation.
+		// Recording it there silences every later exchange, including the one that would otherwise
+		// notice a UPF that came back after this run had already given up waiting for it.
+		if ok && prior.sameRestartAs(recovery) {
+			// Nothing to store: LoadOrStore did not replace the entry when it loaded one, so the run
+			// already repairing this restart is still the recorded one. Re-storing it would risk
+			// clobbering a newer run that a concurrent detection had put there in the meantime.
+			logger.PfcpLog.Infof("UPF[%s] restart already being restored; this is the same restart seen "+
+				"on another exchange, not a second one", nodeIP)
+			return
+		}
+		// The node restarted again while we were still repairing the last restart. Everything the
+		// run in progress is working from describes an incarnation that is already gone, so it is
+		// abandoned rather than completed against a node that has discarded its results.
+		if ok {
+			prior.supersede()
+		}
+		run.displacedAPriorRun = true
+		restorationsInProgress.Store(nodeIP, run)
+		logger.PfcpLog.Warnf("UPF[%s] restarted again during a restoration; the one in progress is abandoned", nodeIP)
+	}
+
+	go func() {
+		defer restorationsInProgress.CompareAndDelete(nodeIP, run)
+		restoreSessions(nodeID, nodeIP, run)
+	}()
+}
+
+// enumerateWithRetry looks again when the sweep found nothing only because sessions were locked.
+//
+// Enumeration takes each session's lock with TryLock and skips what it cannot take, so that one
+// session's procedure cannot stall a sweep of all of them. Giving up on the first attempt is too
+// blunt: a session is locked briefly and often, and under back-to-back restarts every session can be
+// busy at the instant the sweep runs. Measured on a cluster: three restarts in succession, and the
+// second and third each reported "no sessions anchored" while both sessions were merely locked, so
+// nothing was restored and service never came back.
+//
+// Retrying only when sessions were locked out keeps the distinction that matters. A sweep that found
+// nothing because there is nothing has finished; a sweep that found nothing because everything was
+// busy has not looked yet.
+func enumerateWithRetry(nodeID context.NodeID, nodeIP string, run *restorationRun) (anchoredSessions []*context.SMContext, unexaminableAtTheEnd []string, stillEstablishing int) {
+	deadline := time.Now().Add(enumerationWindow)
+	for attempt := 0; ; attempt++ {
+		anchored, unexaminable, establishing := context.SessionsAnchoredOn(nodeID)
+		if len(anchored) > 0 || len(unexaminable) == 0 || !time.Now().Before(deadline) || run.isSuperseded() {
+			if len(unexaminable) > 0 && len(anchored) == 0 {
+				// Reported as a fault only when nothing explains it. A run that displaced another
+				// is the expected case: the displaced one abandons at its next checkpoint but can
+				// still hold a session's lock inside reissue until then, and calling that "none
+				// could be restored" reads as a defect in the restoration rather than two runs
+				// handing over.
+				if run.displacedAPriorRun {
+					logger.PfcpLog.Warnf("UPF[%s] found nothing on %d attempt(s) and %d session(s) could "+
+						"not be examined; the restoration this one displaced has not released them yet, "+
+						"so they are left to the sweep that follows", nodeIP, attempt+1, len(unexaminable))
+				} else {
+					logger.PfcpLog.Errorf("UPF[%s] found nothing on %d attempt(s) and %d session(s) could "+
+						"not be examined; %d of those were last seen anchored here",
+						nodeIP, attempt+1, len(unexaminable), attributableTo(nodeIP, unexaminable))
+				}
+			}
+			return anchored, unexaminable, establishing
+		}
+		time.Sleep(restorationPollInterval)
+	}
+}
+
+func restoreSessions(nodeID context.NodeID, nodeIP string, run *restorationRun) {
+	if !waitForAssociation(nodeID, nodeIP, run) {
+		return
+	}
+
+	anchored, unexaminable, establishing := enumerateWithRetry(nodeID, nodeIP, run)
+	if len(anchored) == 0 {
+		// Two different outcomes, and only one of them is good news. A node with nothing anchored on
+		// it needs nothing done. A node whose every session was locked for the whole window has a
+		// population that is just as dead as before, and saying "nothing to restore" about it --
+		// with the gauge set to zero -- is the exact failure this change exists to remove: a record
+		// that reads healthy over a service that is not. Seen on a cluster at 20 sessions, where the
+		// error naming the locked sweep and the line claiming there was nothing to do were logged
+		// one after the other, and the metric agreed with the wrong one.
+		if stranded := attributableTo(nodeIP, unexaminable); stranded > 0 {
+			logger.PfcpLog.Errorf("UPF[%s] restarted and %d session(s) last seen anchored on it could not be "+
+				"examined within %s; they are left unrestored, not absent (%d session(s) were unexaminable "+
+				"in total, the rest belong elsewhere)", nodeIP, stranded, enumerationWindow, len(unexaminable))
+			metrics.SetUpfUnrestoredSessions(context.SMF_Self().NfInstanceID, nodeIP, stranded)
+			return
+		}
+		if len(unexaminable) > 0 {
+			// Unexaminable, but none of them was ever seen on this node. Saying nothing is anchored
+			// here is the best available answer, and claiming otherwise would put another node's
+			// problem under this node's label.
+			logger.PfcpLog.Warnf("UPF[%s] restarted with nothing anchored on it that could be found; "+
+				"%d session(s) elsewhere could not be examined", nodeIP, len(unexaminable))
+		}
+		if establishing > 0 {
+			// Not an empty node. These are being set up right now and their own establishment owns
+			// them; restoration must not touch one, but nor should it report the node as bare.
+			logger.PfcpLog.Infof("UPF[%s] restarted with no established sessions to restore; %d are "+
+				"still being set up and are left to the paths establishing them", nodeIP, establishing)
+		} else {
+			logger.PfcpLog.Infof("UPF[%s] restarted with no sessions anchored on it; nothing to restore", nodeIP)
+		}
+		metrics.SetUpfUnrestoredSessions(context.SMF_Self().NfInstanceID, nodeIP, 0)
+		return
+	}
+	logger.PfcpLog.Infof("UPF[%s] restarted; restoring %d session(s)", nodeIP, len(anchored))
+	rememberAnchored(nodeIP, anchored)
+
+	// Every anchored session is currently not carrying traffic; the gauge falls as they come back,
+	// so it reads as the outstanding backlog while a restoration is running and as the sessions
+	// left behind once one has finished.
+	metrics.SetUpfUnrestoredSessions(context.SMF_Self().NfInstanceID, nodeIP, len(anchored))
+
+	restored, skipped, unknown, gone := 0, 0, 0, 0
+	unrestored := make([]*context.SMContext, 0)
+	consecutiveFailedWaves := 0
+	for wave := 0; wave < len(anchored); wave += maxRestorationsInFlight {
+		if run.isSuperseded() {
+			logger.PfcpLog.Warnf("UPF[%s] restoration abandoned after %d of %d session(s): superseded by a later restart",
+				nodeIP, restored, len(anchored))
+			// Deliberately without resolving the failures collected so far. They are still anchored
+			// on the node, so the run that superseded this one enumerates them again and may well
+			// restore them against the incarnation that is now current. Releasing them here would
+			// tear down sessions that are about to be repaired, on the evidence of a UPF that no
+			// longer exists.
+			return
+		}
+
+		end := min(wave+maxRestorationsInFlight, len(anchored))
+		batch := anchored[wave:end]
+
+		// Only what was actually sent is waited on. A session reissue skipped was never sent
+		// anything, so the node's silence about it is not evidence of a refusal, and letting it into
+		// the wave would put it on the list this run releases.
+		sent := make([]*context.SMContext, 0, len(batch))
+		for _, smContext := range batch {
+			if reissue(smContext, nodeIP) {
+				sent = append(sent, smContext)
+			} else {
+				skipped++
+			}
+		}
+
+		settled := settleWave(sent, nodeIP)
+		restored += settled.answered
+		unknown += settled.unknown
+		gone += settled.gone
+		unrestored = append(unrestored, settled.unanswered...)
+
+		// A node that is refusing or ignoring everything will not start answering because more is
+		// sent to it. Continuing turns a recoverable restart into a loop that keeps a cold node
+		// under load, so the run stops and says how far it got rather than working through a
+		// population that cannot be restored.
+		//
+		// Judged on answers, not on the absence of them: a wave in which nothing could be examined
+		// is not a wave the node refused, and counting it as one used to stop the run early.
+		if len(sent) > 0 && settled.answered == 0 {
+			consecutiveFailedWaves++
+			if consecutiveFailedWaves >= maxConsecutiveFailedWaves {
+				logger.PfcpLog.Errorf("UPF[%s] restoration stopped after %d consecutive wave(s) with no response: "+
+					"%d restored, %d not restored, %d never attempted, %d could not be examined",
+					nodeIP, consecutiveFailedWaves, restored, len(unrestored), skipped, unknown)
+				finish(nodeIP, restored, skipped, unknown, gone, unrestored)
+				return
+			}
+		} else {
+			consecutiveFailedWaves = 0
+		}
+	}
+
+	logger.PfcpLog.Infof("UPF[%s] restoration complete: %d restored, %d not restored, %d not attempted "+
+		"(busy, purged, or no longer live), %d could not be examined, %d no longer on this node",
+		nodeIP, restored, len(unrestored), skipped, unknown, gone)
+	finish(nodeIP, restored, skipped, unknown, gone, unrestored)
+}
+
+// finish records the outcome and settles whatever the node would not accept.
+//
+// The counts are separate on purpose. A restoration that restored some sessions and released the
+// rest must not be readable as one that simply completed -- that conflation is the shape of the
+// failure this whole change exists to remove, where every available signal reported health while
+// the sessions carried nothing.
+//
+// The unrestored gauge counts what is known to be without service: sessions the node refused, plus
+// those nothing could be learned about. A session that could not be examined has not been shown to
+// be healthy, and leaving it out of the count is how a restoration comes to report success over a
+// population that is still dead.
+func finish(nodeIP string, restored, skipped, unknown, gone int, unrestored []*context.SMContext) {
+	smfID := context.SMF_Self().NfInstanceID
+	metrics.AddUpfRestorationStats(smfID, nodeIP, "restored", restored)
+	metrics.AddUpfRestorationStats(smfID, nodeIP, "skipped", skipped)
+	metrics.AddUpfRestorationStats(smfID, nodeIP, "unexaminable", unknown)
+	metrics.AddUpfRestorationStats(smfID, nodeIP, "gone", gone)
+	// Counted after the releases, not before. A session that was torn down is no longer a session
+	// without service -- the UE will establish a new one -- whereas one the release could not reach
+	// still is, and so is one nothing could be learned about.
+	stillWithoutService := unknown + resolveUnrestorable(unrestored, nodeIP)
+	metrics.SetUpfUnrestoredSessions(smfID, nodeIP, stillWithoutService)
+}
+
+// reissue clears the remote session identifier for this node and re-runs the ordinary activation.
+// Clearing it is what makes that path send an establishment rather than a modification, which is
+// the correct message for a node that holds no session.
+//
+// The liveness re-check is deliberate: the snapshot bounds which sessions are candidates, and this
+// decides whether each one still should be. A session released between the two must not be
+// resurrected.
+func reissue(smContext *context.SMContext, nodeIP string) bool {
+	// Taken with a bounded attempt, not held for. Live subscriber signalling holds this lock too,
+	// and a repair that queues ahead of it delays the subscriber for no benefit -- the session can
+	// as easily be restored on the next sweep. This bounds how long restoration waits; sending
+	// outside the lock, below, bounds how long it holds.
+	if !tryLockFor(&smContext.SMLock, lockAcquireTimeout) {
+		smContext.SubPfcpLog.Infof("session is busy; leaving it for the next sweep")
+		return false
+	}
+	unlocked := false
+	release := func() {
+		if !unlocked {
+			smContext.SMLock.Unlock()
+			unlocked = true
+		}
+	}
+	defer release()
+
+	pfcpContext, stillAnchored := smContext.PFCPContext[nodeIP]
+	if !stillAnchored {
+		return false
+	}
+	if smContext.SMContextState == context.SmStateRelease {
+		return false
+	}
+	// Set as the first act of replacing a session. The context is on its way out and the
+	// replacement is waiting for this very lock, so restoring it would repair something that is
+	// about to be discarded while delaying the session taking its place.
+	if smContext.LocalPurged {
+		smContext.SubPfcpLog.Infof("session has been purged and replaced; not restoring it")
+		return false
+	}
+	// Restoration walks every session anchored on the node, including any caught part-way through
+	// establishment or teardown. The activation path dereferences the tunnel, so a session without
+	// one is skipped rather than allowed to panic a goroutine that is repairing an outage.
+	if smContext.Tunnel == nil {
+		smContext.SubPfcpLog.Warnf("session has no tunnel and cannot be restored")
+		return false
+	}
+
+	// Take back the response to the last establishment this restoration issued, which nothing
+	// consumed.
+	//
+	// SBIPFCPCommunicationChan holds one value. In the ordinary flow a request is sent by a
+	// procedure that then waits on this channel, so every response is taken. Restoration sends
+	// establishments and waits on the remote identifier instead, so its responses accumulate -- and
+	// the second restoration of a session finds the channel full. HandlePfcpSessionEstablishmentResponse
+	// sends into it *while holding SMLock*, so the send blocks forever and the session's lock is
+	// never released. Every later sweep then skips that session, and it can never be restored again.
+	//
+	// Observed on a cluster: 20 sessions, all permanently locked, 20 goroutines parked in `chan send`
+	// inside that handler, and each restart reporting "every anchored session was locked".
+	//
+	// Safe to take here because no legitimate waiter can be parked on this channel for this session
+	// right now. The modification and release paths hold SMLock across their receive, so they cannot
+	// run while this does; and the establishment path, which waits without the lock, only does so for
+	// a session that has never been acknowledged -- which the enumeration excludes.
+	select {
+	case <-smContext.SBIPFCPCommunicationChan:
+		smContext.SubPfcpLog.Debugf("discarded an unconsumed PFCP response from an earlier restoration")
+	default:
+	}
+
+	pfcpContext.RemoteSEID = 0
+	pfcpContext.ClearedByRestoration = true
+	markRulesUncreated(smContext, nodeIP)
+	nameTheUeAddressInUse(smContext, nodeIP)
+	pinUplinkTunnelsToTheirExistingTeids(smContext, nodeIP)
+
+	// Sent under the lock, as the establishment path does. SendPFCPRules reads the tunnel, the data
+	// path and the PFCP context, all of which other code mutates under this lock, so releasing first
+	// would trade the stall this change fixes for a race -- which the race detector duly caught when
+	// it was tried. On the native datapath the send is a UDP write and the hold is microseconds.
+	//
+	// It is not bounded on the adapter datapath, where the same call becomes an HTTP POST. That is
+	// recorded as a follow-up rather than fixed here: it needs the rules snapshotting so the send
+	// can happen outside the lock, and it cannot be reached in a deployment that has the adapter
+	// disabled.
+	SendPFCPRules(smContext)
+	return true
+}
+
+// tryLockFor acquires the lock if it can be had within d, and reports whether it did.
+//
+// sync.Mutex offers TryLock but no bounded wait, and neither extreme suits a repair: failing on the
+// first attempt gives up while a lock is held for microseconds, and waiting without limit is what
+// let restoration stall a subscriber.
+func tryLockFor(mu *sync.Mutex, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if mu.TryLock() {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// markRulesUncreated puts the session's rules for this node back to the state that means "not yet
+// on the user plane", because that is now true of all of them.
+//
+// The establishment builder emits a rule only when its state is RULE_INITIAL, and advances it to
+// RULE_CREATE once sent. After the first establishment the session's FARs and QERs therefore say
+// they exist on the user plane. They did, on the incarnation that is gone. Re-sending without
+// correcting that produces an establishment carrying a PDR and nothing else: the packet matches the
+// rule and then has no forwarding action and no QoS rule to act under. Measured on a cluster as a
+// correct PDR installed alongside "need at least 1 QER in PDR or 2 QERs in session".
+//
+// PDRs are re-sent today only because the builder never advances their state, which is an asymmetry
+// in that code rather than a decision. Resetting all three makes the behaviour deliberate instead of
+// dependent on it.
+//
+// Scoped to the node that restarted: rules on another user plane are still installed there, and
+// telling this session they are not would re-create them on a node that already has them.
+// nameTheUeAddressInUse corrects the UE address on every rule for this node, in both directions.
+//
+// The uplink rule matches on the tunnel, the downlink rule matches on the UE address, and both were
+// built carrying the address the SMF proposed rather than the one the user plane allocated. Fixing
+// only the uplink leaves downlink matching an address the UE does not have, so traffic reaches the
+// subscriber's session and no reply ever comes back -- which reads exactly like the uplink still
+// being broken.
+func nameTheUeAddressInUse(smContext *context.SMContext, nodeIP string) {
+	for _, dataPath := range smContext.Tunnel.DataPathPool {
+		for node := dataPath.FirstDPNode; node != nil; node = node.Next() {
+			if node.UPF == nil || node.UPF.NodeID.ResolveNodeIdToIp().String() != nodeIP {
+				continue
+			}
+			for _, tunnel := range []*context.GTPTunnel{node.UpLinkTunnel, node.DownLinkTunnel} {
+				if tunnel == nil {
+					continue
+				}
+				for _, pdr := range tunnel.PDR {
+					if pdr != nil {
+						pinUeAddress(smContext, pdr)
+					}
+				}
+			}
+		}
+	}
+}
+
+func markRulesUncreated(smContext *context.SMContext, nodeIP string) {
+	rules := 0
+	for _, dataPath := range smContext.Tunnel.DataPathPool {
+		for node := dataPath.FirstDPNode; node != nil; node = node.Next() {
+			if node.UPF == nil || node.UPF.NodeID.ResolveNodeIdToIp().String() != nodeIP {
+				continue
+			}
+			for _, tunnel := range []*context.GTPTunnel{node.UpLinkTunnel, node.DownLinkTunnel} {
+				if tunnel == nil {
+					continue
+				}
+				for _, pdr := range tunnel.PDR {
+					if pdr == nil {
+						continue
+					}
+					pdr.State = context.RULE_INITIAL
+					rules++
+					if pdr.FAR != nil {
+						pdr.FAR.State = context.RULE_INITIAL
+						rules++
+					}
+					for _, qer := range pdr.QER {
+						if qer != nil {
+							qer.State = context.RULE_INITIAL
+							rules++
+						}
+					}
+				}
+			}
+		}
+	}
+	smContext.SubPfcpLog.Infof("marked %d rule(s) for UPF[%s] as not yet installed, so the "+
+		"re-establishment carries all of them", rules, nodeIP)
+}
+
+// pinUplinkTunnelsToTheirExistingTeids makes the re-installed uplink PDRs name the tunnel the RAN is
+// already using, rather than asking the UPF to allocate a new one.
+//
+// Establishment normally sets the F-TEID's CHOOSE flag and lets the UPF pick, and the SMF then tells
+// the RAN which tunnel to send on. That is right the first time and wrong on a restart: the UPF picks
+// a second TEID, the RAN is never told, and every uplink packet keeps arriving on the old one and
+// misses the table. Observed on a cluster as pdrLookupFail counting every packet while the
+// restoration reported success.
+//
+// A restarted UPF holds no tunnels, so the one it used before is free for it to be given back. This
+// is the same reasoning as carrying the rule identifiers over: the value means something to the UPF
+// only while it holds the rule that names it.
+func pinUplinkTunnelsToTheirExistingTeids(smContext *context.SMContext, nodeIP string) {
+	pinned, skipped := 0, 0
+	for _, dataPath := range smContext.Tunnel.DataPathPool {
+		for node := dataPath.FirstDPNode; node != nil; node = node.Next() {
+			if node.UPF == nil || node.UPF.NodeID.ResolveNodeIdToIp().String() != nodeIP {
+				continue
+			}
+			if node.UpLinkTunnel == nil || node.UpLinkTunnel.TEID == 0 {
+				// Never established, so there is no tunnel to preserve. Not a fault.
+				continue
+			}
+			access := accessAddressOf(node.UPF, smContext.SelectedPDUSessionType)
+			if access == nil {
+				// Said out loud, because the alternative is a repair that quietly does nothing. An
+				// F-TEID carrying the V4 flag and no address is malformed and the UPF rejects the
+				// whole establishment, so the pin is skipped instead -- and a silent skip is
+				// indistinguishable, from outside, from a pin that worked.
+				smContext.SubPfcpLog.Warnf("uplink tunnel NOT pinned for UPF[%s]: no N3 address "+
+					"(session type %d, %d N3 interface(s)); the UPF will choose a new TEID and the RAN "+
+					"will keep sending on the old one",
+					nodeIP, smContext.SelectedPDUSessionType, n3InterfaceCount(node.UPF))
+				skipped++
+				continue
+			}
+			for _, pdr := range node.UpLinkTunnel.PDR {
+				if pdr == nil || pdr.PDI.LocalFTeid == nil {
+					continue
+				}
+				pdr.PDI.LocalFTeid = &context.FTEID{
+					V4:          true,
+					Teid:        node.UpLinkTunnel.TEID,
+					Ipv4Address: access,
+				}
+				pinned++
+			}
+			if pinned > 0 {
+				smContext.SubPfcpLog.Infof("uplink tunnel pinned for UPF[%s]: TEID %#x at %s, %d rule(s)",
+					nodeIP, node.UpLinkTunnel.TEID, access, pinned)
+			}
+		}
+	}
+	if pinned == 0 && skipped == 0 {
+		smContext.SubPfcpLog.Warnf("uplink tunnel NOT pinned for UPF[%s]: no uplink rule on this node "+
+			"carried a tunnel to preserve", nodeIP)
+	}
+}
+
+// pinUeAddress makes the re-installed rule name the address the UE actually holds.
+//
+// Where the user plane allocates UE addresses, it returns its choice in the establishment response
+// and the SMF records it on the session — but the rule that was built before the request still
+// carries the address the SMF had proposed. That never mattered, because the node had chosen the
+// address itself and installed the rule accordingly. On a restart it matters completely: the SMF
+// re-sends the rule it built, the node installs it verbatim, and the rule names an address the UE
+// does not have. Observed on a cluster as a restored rule for 192.168.100.1 while the live UE held
+// 192.168.100.3, with every uplink packet missing the table.
+//
+// This is the same fault as the tunnel identifier, in a second field: a value the user plane chose,
+// of which the SMF holds a stale copy that only surfaces when the rule is sent a second time.
+func pinUeAddress(smContext *context.SMContext, pdr *context.PDR) {
+	if pdr.PDI.UEIPAddress == nil || smContext.PDUAddress == nil || smContext.PDUAddress.Ip == nil {
+		return
+	}
+	if !pdr.PDI.UEIPAddress.CHV4 && pdr.PDI.UEIPAddress.Ipv4Address.Equal(smContext.PDUAddress.Ip) {
+		return
+	}
+	smContext.SubPfcpLog.Infof("re-installed rule asked the UPF to choose a UE address (CHV4=%t, "+
+		"carried %v); naming the address in use instead, %s",
+		pdr.PDI.UEIPAddress.CHV4, pdr.PDI.UEIPAddress.Ipv4Address, smContext.PDUAddress.Ip)
+
+	// Clearing CHV4 is the whole of it. Setting the address while the choose flag is still set
+	// changes nothing: the user plane ignores the value and allocates from its own pool, which a
+	// restart has just reset, so it hands out an address the UE has never held. Observed on a
+	// cluster as a restored rule for 192.168.100.1 while the UE held 192.168.100.2.
+	pdr.PDI.UEIPAddress.CHV4 = false
+	pdr.PDI.UEIPAddress.V4 = true
+	pdr.PDI.UEIPAddress.Ipv4Address = smContext.PDUAddress.Ip
+}
+
+func n3InterfaceCount(upf *context.UPF) int {
+	upf.UpfLock.RLock()
+	defer upf.UpfLock.RUnlock()
+	return len(upf.N3Interfaces)
+}
+
+// accessAddressOf returns the N3 address the RAN was told to send to.
+//
+// It resolves it the same way the N2 setup did, through UPFInterfaceInfo.IP on the first N3
+// interface. Reading IPv4EndPointAddresses directly is not equivalent: an interface configured by
+// FQDN carries no address there, and an earlier version of this returned nil for exactly that
+// reason, then built an F-TEID with the V4 flag and no address, which the UPF rejected as missing a
+// mandatory IE.
+//
+// Deriving it the same way as the N2 build is the point, not a convenience: the address pinned here
+// has to be the one the RAN is sending to, and that is the only way to be sure of it.
+func accessAddressOf(upf *context.UPF, pduSessionType uint8) net.IP {
+	upf.UpfLock.RLock()
+	defer upf.UpfLock.RUnlock()
+	if len(upf.N3Interfaces) == 0 {
+		return nil
+	}
+	address, err := upf.N3Interfaces[0].IP(pduSessionType)
+	if err != nil {
+		return nil
+	}
+	return address
+}
+
+// A wave is given a chance to settle before the next is issued, so the bound is on requests
+// outstanding rather than on how fast a loop can run.
+//
+// A session in a wave ends in one of four states, and conflating any two of them has cost a defect.
+// "Answered" and "not answered" are conclusions; "could not be examined" is the absence of one, and
+// treating it as either a success or a refusal is how a wave came to report sessions restored that
+// nobody had looked at.
+type waveOutcome int
+
+const (
+	waveAnswered   waveOutcome = iota // the node accepted it: it has a remote identifier again
+	waveUnanswered                    // examined, and the node has not answered
+	waveUnknown                       // its lock could not be taken, so nothing is known
+	waveGone                          // no longer anchored on this node; not this run's business
+)
+
+func outcomeOf(smContext *context.SMContext, nodeIP string) waveOutcome {
+	// TryLock, for the same reason the enumeration uses it: SMLock is held across network calls in
+	// this codebase, so a blocking acquire here is an unbounded wait inside the wave loop. It hung a
+	// run at 50 sessions on a cluster.
+	if !smContext.SMLock.TryLock() {
+		return waveUnknown
+	}
+	defer smContext.SMLock.Unlock()
+
+	pfcpContext, onThisNode := smContext.PFCPContext[nodeIP]
+	switch {
+	case !onThisNode:
+		return waveGone
+	case pfcpContext.RemoteSEID == 0:
+		return waveUnanswered
+	default:
+		return waveAnswered
+	}
+}
+
+type waveResult struct {
+	answered   int
+	unanswered []*context.SMContext
+	unknown    int
+	gone       int
+}
+
+// settleWave gives the UPF a chance to answer the establishments this wave issued, and reports what
+// is actually known when the time is up.
+//
+// Only sessions this wave issued are passed in. A session reissue skipped was never sent anything,
+// so the node's silence about it says nothing -- and it must never reach the unanswered set, which
+// is what gets released.
+func settleWave(issued []*context.SMContext, nodeIP string) waveResult {
+	deadline := time.Now().Add(restorationSettleTimeout)
+	result := waveResult{unanswered: make([]*context.SMContext, 0)}
+	pending := issued
+
+	for {
+		stillPending := make([]*context.SMContext, 0, len(pending))
+		for _, smContext := range pending {
+			switch outcomeOf(smContext, nodeIP) {
+			case waveAnswered:
+				result.answered++
+			case waveGone:
+				result.gone++
+			case waveUnanswered, waveUnknown:
+				stillPending = append(stillPending, smContext)
+			}
+		}
+		pending = stillPending
+		if len(pending) == 0 || !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(restorationPollInterval)
+	}
+
+	// Classify once more at the deadline so a session whose lock freed at the last moment is judged
+	// on what it says rather than on the fact that it was busy earlier.
+	for _, smContext := range pending {
+		switch outcomeOf(smContext, nodeIP) {
+		case waveAnswered:
+			result.answered++
+		case waveGone:
+			result.gone++
+		case waveUnknown:
+			result.unknown++
+		case waveUnanswered:
+			result.unanswered = append(result.unanswered, smContext)
+		}
+	}
+	return result
+}
+
+// resolveUnrestorable settles the sessions the UPF would not accept.
+//
+// The outcome that must not occur is the one that exists before this change for every session: a
+// record describing a working service that does not exist. A released session is a fact the rest of
+// the system can act on; a session reported as active but forwarding nothing is undiagnosable from
+// the control plane, because every signal it offers says the service is running.
+func resolveUnrestorable(unrestored []*context.SMContext, nodeIP string) (notReleased int) {
+	if len(unrestored) == 0 {
+		return 0
+	}
+	released := 0
+	for _, smContext := range unrestored {
+		smContext.SubPfcpLog.Errorf("session could not be restored on UPF[%s]; releasing it", nodeIP)
+		if err := releaseOneSession(smContext); err != nil {
+			smContext.SubPfcpLog.Errorf("releasing the unrestorable session failed: %v", err)
+			continue
+		}
+		released++
+	}
+	logger.PfcpLog.Errorf("UPF[%s] %d session(s) could not be restored, %d released", nodeIP, len(unrestored), released)
+	metrics.AddUpfRestorationStats(context.SMF_Self().NfInstanceID, nodeIP, "released", released)
+	return len(unrestored) - released
+}
+
+// releaseUnrestorableSession tears down a session the restarted UPF would not accept, and tells the
+// peers that hold state for it.
+//
+// The UE has to be told. It observed nothing when the UPF restarted — the radio is up, the cell is
+// present, its mobility state did not change — so there is no procedure on its side that would
+// discover the loss and no timer that expires into one. A session left in place is one the UE
+// believes it can use indefinitely. Releasing it is what lets the UE establish a working one.
+//
+// Both peers are told even if one fails, because a session half-released is worse than either
+// outcome: the PCF holding a policy association for a session the UE has been told to drop, or the
+// UE still holding a session whose policy is gone.
+// releaseOneSession isolates a single release, so one session cannot take the process with it.
+//
+// This runs on a background goroutine, over whatever sessions happen to be anchored on the node,
+// while the network is already degraded. Some of them are caught part-way through establishment and
+// do not yet carry the fields the release path reads. A panic here would turn a UPF restart into an
+// SMF restart, which loses every session on every UPF rather than the ones on this one.
+func releaseOneSession(smContext *context.SMContext) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("releasing the session panicked: %v", r)
+		}
+	}()
+	return releaseUnrestorableSession(smContext)
+}
+
+var errSessionBusy = errors.New("session is busy")
+
+// markReleasedAndBuild does the in-memory half of the release under SMLock: the state change and
+// assembling the transfer, both of which touch fields other paths mutate under that lock.
+//
+// The unlock is deferred rather than written after the work. ChangeState indexes into the data path
+// pool and can panic on a malformed context, and releaseOneSession recovers -- so an un-deferred
+// unlock leaks the lock silently, and every later sweep then finds the session unexaminable. That
+// is not hypothetical: it happened while making this very change, and the sweep tests caught it.
+func markReleasedAndBuild(smContext *context.SMContext) (*models.N1N2MessageTransferRequest, error) {
+	if !tryLockFor(&smContext.SMLock, lockAcquireTimeout) {
+		return nil, errSessionBusy
+	}
+	defer smContext.SMLock.Unlock()
+
+	smContext.ChangeState(context.SmStateRelease)
+	return buildReleaseCommandForUE(smContext)
+}
+
+// deleteSmPolicy terminates the policy association with SMLock held, as the ordinary release path
+// does at producer/pdu_session.go. This is a PCF call without the re-discovery loop that made the
+// AMF transfer too dangerous to hold the lock for.
+func deleteSmPolicy(smContext *context.SMContext) error {
+	if !tryLockFor(&smContext.SMLock, lockAcquireTimeout) {
+		return errSessionBusy
+	}
+	defer smContext.SMLock.Unlock()
+
+	_, err := consumer.SendSMPolicyAssociationDelete(smContext, &models.ReleaseSmContextRequest{})
+	return err
+}
+
+func releaseUnrestorableSession(smContext *context.SMContext) error {
+	n1n2Request, buildErr := markReleasedAndBuild(smContext)
+
+	// Cleaned up whether or not the build succeeded: a build that failed part-way has already staged
+	// the payloads it got through, and the request is returned for exactly that reason.
+	if n1n2Request != nil {
+		defer util.CleanupMultipartTempFiles(n1n2Request)
+	}
+	if buildErr != nil {
+		return buildErr
+	}
+
+	var firstErr error
+	// The transfer is deliberately not under SMLock -- see the note inside transferReleaseCommand's
+	// body. The residual is that AMF re-discovery can mutate the serving-AMF fields while this reads
+	// them; accepted, because holding the lock here was measured to stop an unrelated subscriber from
+	// establishing a session at all.
+	if err := transferReleaseCommand(smContext, n1n2Request); err != nil {
+		firstErr = err
+	}
+
+	if err := deleteSmPolicy(smContext); err != nil {
+		smContext.SubPduSessLog.Errorf("terminating the SM policy association failed: %v", err)
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// buildReleaseCommandForUE assembles the transfer. The caller must hold SMLock: every field read
+// here is one other paths mutate under it. The caller is also responsible for releasing the
+// temporary files, which is why the cleanup is not deferred inside.
+func buildReleaseCommandForUE(smContext *context.SMContext) (*models.N1N2MessageTransferRequest, error) {
+	n1n2Request := models.NewN1N2MessageTransferRequest()
+
+	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
+	n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_REL_CMD)
+	smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
+	smInfo.SetN2InfoContent(*n2InfoContent)
+	if smContext.Snssai != nil {
+		smInfo.SetSNssai(*smContext.Snssai)
+	}
+	n2InfoContainer := models.NewN2InfoContainer(models.N2INFORMATIONCLASS_SM)
+	n2InfoContainer.SetSmInfo(*smInfo)
+
+	n1MessageClass, err := models.NewN1MessageClassFromValue("SM")
+	if err != nil {
+		return n1n2Request, fmt.Errorf("create N1 message class: %w", err)
+	}
+	n1MsgContainer := models.NewN1MessageContainer(*n1MessageClass, *models.NewRefToBinaryData("GSM_NAS"))
+
+	n1n2Request.SetJsonData(*models.NewN1N2MessageTransferReqData())
+	jsonData := n1n2Request.GetJsonData()
+	jsonData.SetPduSessionId(smContext.PDUSessionID)
+	n1n2Request.SetJsonData(jsonData)
+
+	nasBuf, err := context.BuildGSMPDUSessionReleaseCommand(smContext)
+	if err != nil {
+		return n1n2Request, fmt.Errorf("build PDU Session Release Command: %w", err)
+	}
+	nasFile, err := util.CreatePayloadTempFile(nasBuf)
+	if err != nil {
+		return n1n2Request, fmt.Errorf("stage the N1 payload: %w", err)
+	}
+	n1n2Request.SetBinaryDataN1Message(nasFile)
+	jsonData = n1n2Request.GetJsonData()
+	jsonData.SetN1MessageContainer(*n1MsgContainer)
+	n1n2Request.SetJsonData(jsonData)
+
+	n2Pdu, err := context.BuildPDUSessionResourceReleaseCommandTransfer(smContext)
+	if err != nil {
+		return n1n2Request, fmt.Errorf("build PDUSessionResourceReleaseCommandTransfer: %w", err)
+	}
+	n2File, err := util.CreatePayloadTempFile(n2Pdu)
+	if err != nil {
+		return n1n2Request, fmt.Errorf("stage the N2 payload: %w", err)
+	}
+	n1n2Request.SetBinaryDataN2Information(n2File)
+	jsonData = n1n2Request.GetJsonData()
+	jsonData.SetN2InfoContainer(*n2InfoContainer)
+	n1n2Request.SetJsonData(jsonData)
+
+	// Deliberately NOT under SMLock, unlike the QoS transfer in callback.go.
+	//
+	// That one holds the lock across its transfer so AMF re-discovery's mutation of the serving-AMF
+	// fields cannot race other users of the context, and for request-scoped code that is right: the
+	// call is bounded by the caller's timeout and it blocks only the subscriber it is serving.
+	//
+	// This is a background sweep over whatever sessions happen to be anchored on a restarted node,
+	// and the same lock is what a replacing session needs in order to purge the context it is
+	// replacing. Holding it across an AMF call with re-discovery and retries therefore stops an
+	// unrelated subscriber from establishing a session at all. Measured on a cluster while the AMF
+	// was answering 404: the purge logged and then hung, and the UE retransmitted until T3580 for
+	// minutes. A best-effort repair must not be able to do that.
+	return n1n2Request, nil
+}
+
+// transferReleaseCommand sends what was built, without SMLock.
+func transferReleaseCommand(smContext *context.SMContext, n1n2Request *models.N1N2MessageTransferRequest) error {
+	rspData, err := consumer.SendN1N2TransferWithRediscovery(gocontext.Background(), smContext, n1n2Request)
+	if err != nil {
+		return fmt.Errorf("N1N2 transfer: %w", err)
+	}
+	if rspData.GetCause() == models.N1N2MESSAGETRANSFERCAUSE_N1_MSG_NOT_TRANSFERRED {
+		return fmt.Errorf("N1N2 transfer refused: %v", rspData.GetCause())
+	}
+	return nil
+}
+
+// waitForAssociation holds the restoration back until the PFCP association with the restarted UPF
+// has been re-established.
+//
+// A restart is noticed on the heartbeat path before the association is back: that path marks the
+// UPF NotAssociated precisely so ProbeInactiveUpfs will re-associate it. Session establishments
+// issued in that gap are rejected -- observed on a cluster as PFCP cause 72 -- and, worse, a
+// rejection is indistinguishable from a session the UPF will not accept, so restoration would
+// release sessions that were only asked too early.
+//
+// Returns false if the association does not come back in time, or if a later restart has
+// superseded this run, in which case there is nothing useful left to do here.
+func waitForAssociation(nodeID context.NodeID, nodeIP string, run *restorationRun) bool {
+	deadline := time.Now().Add(associationWaitTimeout)
+	for {
+		if run.isSuperseded() {
+			return false
+		}
+		upf := context.RetrieveUPFNodeByNodeID(nodeID)
+		if upf == nil {
+			logger.PfcpLog.Errorf("UPF[%s] is no longer known; abandoning the restoration", nodeIP)
+			return false
+		}
+		upf.UpfLock.RLock()
+		associated := upf.UPFStatus == context.AssociatedSetUpSuccess
+		upf.UpfLock.RUnlock()
+		if associated {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			logger.PfcpLog.Errorf("UPF[%s] did not re-associate within %s; sessions are left un-restored "+
+				"rather than established into a node that cannot accept them", nodeIP, associationWaitTimeout)
+			return false
+		}
+		time.Sleep(restorationPollInterval)
+	}
+}

--- a/producer/restoration.go
+++ b/producer/restoration.go
@@ -878,7 +878,7 @@ func releaseUnrestorableSession(smContext *context.SMContext) error {
 func buildReleaseCommandForUE(smContext *context.SMContext) (*models.N1N2MessageTransferRequest, error) {
 	n1n2Request := models.NewN1N2MessageTransferRequest()
 
-	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: "N2SmInformation"})
+	n2InfoContent := models.NewN2InfoContent(models.RefToBinaryData{ContentId: n2SmInformationContentID})
 	n2InfoContent.SetNgapIeType(models.NGAPIETYPE_PDU_RES_REL_CMD)
 	smInfo := models.NewN2SmInformation(smContext.PDUSessionID)
 	smInfo.SetN2InfoContent(*n2InfoContent)

--- a/producer/restoration.go
+++ b/producer/restoration.go
@@ -580,6 +580,11 @@ func pinUplinkTunnelsToTheirExistingTeids(smContext *context.SMContext, nodeIP s
 				skipped++
 				continue
 			}
+			// Counted per node as well as in total. The line below names this node's TEID and
+			// address, so reporting the running total beside them would attribute another node's
+			// rules to this one -- and would log a pin for a node that pinned nothing, as soon as
+			// any earlier node had pinned something.
+			nodePinned := 0
 			for _, pdr := range node.UpLinkTunnel.PDR {
 				if pdr == nil || pdr.PDI.LocalFTeid == nil {
 					continue
@@ -589,11 +594,12 @@ func pinUplinkTunnelsToTheirExistingTeids(smContext *context.SMContext, nodeIP s
 					Teid:        node.UpLinkTunnel.TEID,
 					Ipv4Address: access,
 				}
-				pinned++
+				nodePinned++
 			}
-			if pinned > 0 {
+			pinned += nodePinned
+			if nodePinned > 0 {
 				smContext.SubPfcpLog.Infof("uplink tunnel pinned for UPF[%s]: TEID %#x at %s, %d rule(s)",
-					nodeIP, node.UpLinkTunnel.TEID, access, pinned)
+					nodeIP, node.UpLinkTunnel.TEID, access, nodePinned)
 			}
 		}
 	}

--- a/producer/restoration_internal_test.go
+++ b/producer/restoration_internal_test.go
@@ -1,0 +1,719 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/omec-project/smf/context"
+)
+
+const (
+	restarted = "10.30.0.1"
+	untouched = "10.30.0.2"
+)
+
+func sessionOn(t *testing.T, supi string, psi int32, nodeIPs ...string) *context.SMContext {
+	t.Helper()
+	smContext := context.NewSMContext(supi, psi)
+	smContext.Tunnel = &context.UPTunnel{DataPathPool: context.DataPathPool{}}
+	smContext.SMLock.Lock()
+	defer smContext.SMLock.Unlock()
+	for i, ip := range nodeIPs {
+		smContext.PFCPContext[ip] = &context.PFCPSessionContext{
+			NodeID:     *context.NewNodeID(ip),
+			LocalSEID:  uint64(500 + i),
+			RemoteSEID: uint64(900 + i),
+		}
+	}
+	return smContext
+}
+
+// Clearing the remote identifier is the whole trigger: the activation path sends an establishment
+// rather than a modification when it is zero, which is the correct message for a node holding no
+// session.
+func TestReissueClearsTheRemoteIdentifierForThatNodeOnly(t *testing.T) {
+	smContext := sessionOn(t, "imsi-208930000000101", 1, restarted, untouched)
+
+	if !reissue(smContext, restarted) {
+		t.Fatalf("expected the session to be re-issued")
+	}
+	if got := smContext.PFCPContext[restarted].RemoteSEID; got != 0 {
+		t.Errorf("remote identifier for the restarted node is %d, want 0 — the activation path will "+
+			"send a modification to a node that holds no session", got)
+	}
+	if got := smContext.PFCPContext[untouched].RemoteSEID; got == 0 {
+		t.Errorf("remote identifier for a node that did not restart was cleared; its session is intact " +
+			"and re-establishing it would replace working forwarding state")
+	}
+}
+
+// The snapshot bounds which sessions are candidates; this decides whether each still should be.
+func TestReissueSkipsASessionReleasedSinceTheSnapshot(t *testing.T) {
+	smContext := sessionOn(t, "imsi-208930000000102", 2, restarted)
+	smContext.ChangeState(context.SmStateRelease)
+
+	if reissue(smContext, restarted) {
+		t.Errorf("a session being released was re-issued; restoration must not resurrect it")
+	}
+}
+
+func TestReissueSkipsASessionNoLongerOnThatNode(t *testing.T) {
+	smContext := sessionOn(t, "imsi-208930000000103", 3, untouched)
+
+	if reissue(smContext, restarted) {
+		t.Errorf("a session that is not anchored on the restarted node was re-issued")
+	}
+}
+
+// A session caught without a tunnel must not panic the goroutine that is repairing an outage.
+func TestReissueSurvivesASessionWithNoTunnel(t *testing.T) {
+	smContext := sessionOn(t, "imsi-208930000000104", 4, restarted)
+	smContext.Tunnel = nil
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("restoration panicked on a session with no tunnel: %v", r)
+		}
+	}()
+	if reissue(smContext, restarted) {
+		t.Errorf("a session with no tunnel was counted as re-issued")
+	}
+}
+
+// A session whose remote identifier is still unset was never established: the establishment
+// response is what sets it. Those are the ones that could not be restored.
+func TestStillUnansweredIdentifiesOnlyTheSessionsTheNodeDidNotAccept(t *testing.T) {
+	answered := sessionOn(t, "imsi-208930000000105", 5, restarted)
+	unanswered := sessionOn(t, "imsi-208930000000106", 6, restarted)
+	unanswered.PFCPContext[restarted].RemoteSEID = 0
+	elsewhere := sessionOn(t, "imsi-208930000000107", 7, untouched)
+
+	if got := outcomeOf(answered, restarted); got != waveAnswered {
+		t.Errorf("a session the node acknowledged classified as %v, want waveAnswered", got)
+	}
+	if got := outcomeOf(unanswered, restarted); got != waveUnanswered {
+		t.Errorf("a session the node did not answer for classified as %v, want waveUnanswered", got)
+	}
+	if got := outcomeOf(elsewhere, restarted); got != waveGone {
+		t.Errorf("a session anchored on another node classified as %v, want waveGone", got)
+	}
+}
+
+// A node restarting during its own restoration is not a remote case: it is what an
+// under-provisioned or crash-looping node does, and restoration adds load exactly when it is least
+// able to take it. Everything the run in progress is working from describes an incarnation that is
+// already gone.
+func TestASecondRestartSupersedesTheRestorationInProgress(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.9")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+
+	first := &restorationRun{}
+	restorationsInProgress.Store(nodeIP, first)
+	defer restorationsInProgress.Delete(nodeIP)
+
+	if first.isSuperseded() {
+		t.Fatalf("precondition: a fresh run must not be superseded")
+	}
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	if !first.isSuperseded() {
+		t.Errorf("the restoration in progress was not superseded by a second restart; it would go on " +
+			"installing sessions derived from an incarnation the node has already discarded, and " +
+			"finish by reporting a restoration that did not happen")
+	}
+}
+
+// The replacement must actually take over, or a third restart would supersede a run that is no
+// longer the current one and leave the second running against stale state.
+func TestTheSupersedingRunReplacesTheOneItAbandoned(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.10")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+
+	first := &restorationRun{}
+	restorationsInProgress.Store(nodeIP, first)
+	defer restorationsInProgress.Delete(nodeIP)
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	current, ok := restorationsInProgress.Load(nodeIP)
+	if !ok {
+		t.Fatalf("no restoration recorded for the node after a second restart")
+	}
+	if current == any(first) {
+		t.Errorf("the abandoned run is still recorded as the current one")
+	}
+}
+
+// The bound exists because every session anchored on the node needs re-installing at the same
+// moment and the node has just started. Issuing them as fast as they can be generated points the
+// whole population at a cold node, and one that falls over under that load restarts again.
+func TestOutstandingRequestsNeverExceedTheBound(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.20"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+
+	const population = 40
+	sessions := make([]*context.SMContext, 0, population)
+	for i := range population {
+		sessions = append(sessions, sessionOn(t, fmt.Sprintf("imsi-2089300000005%02d", i), int32(i+1), nodeIP))
+	}
+
+	// Stand in for the UPF: answer each issued establishment shortly after it is sent, so the run
+	// progresses through its waves the way it would against a live node.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			for _, smContext := range sessions {
+				smContext.SMLock.Lock()
+				if c, ok := smContext.PFCPContext[nodeIP]; ok && c.RemoteSEID == 0 {
+					c.RemoteSEID = 4242
+				}
+				smContext.SMLock.Unlock()
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	// Sample how many are outstanding while the run proceeds.
+	peak := int32(0)
+	watching := make(chan struct{})
+	go func() {
+		defer close(watching)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			outstanding := int32(outstandingIn(sessions, nodeIP))
+			for {
+				current := atomic.LoadInt32(&peak)
+				if outstanding <= current || atomic.CompareAndSwapInt32(&peak, current, outstanding) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	restoreSessions(nodeID, nodeIP, &restorationRun{})
+
+	if got := int(atomic.LoadInt32(&peak)); got > maxRestorationsInFlight {
+		t.Errorf("%d requests were outstanding at once, bound is %d; a population of %d was pointed at a "+
+			"node that had just restarted", got, maxRestorationsInFlight, population)
+	}
+}
+
+// A node refusing everything must produce a bounded attempt, not a loop that keeps a cold node
+// under load until it falls over again.
+func TestARefusingNodeStopsTheRunRatherThanLoopingOverThePopulation(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.21"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+
+	// The population is large enough that stopping and not stopping are far apart in time: 200
+	// sessions is 25 waves if the run works through them all, against the 3 it should take. A
+	// smaller population puts the two within noise of each other, and the test then passes whether
+	// or not the run actually stops.
+	const population = 200
+	for i := range population {
+		sessionOn(t, fmt.Sprintf("imsi-208930000006%03d", i), int32(i+1), nodeIP)
+	}
+
+	start := time.Now()
+	restoreSessions(nodeID, nodeIP, &restorationRun{}) // nothing answers
+	elapsed := time.Since(start)
+
+	waves := (population + maxRestorationsInFlight - 1) / maxRestorationsInFlight
+	budget := time.Duration(maxConsecutiveFailedWaves+2) * restorationSettleTimeout
+	if elapsed > budget {
+		t.Errorf("the run took %v against a node answering nothing, over a budget of %v; it should stop "+
+			"after %d unanswered wave(s) rather than working through all %d",
+			elapsed, budget, maxConsecutiveFailedWaves, waves)
+	}
+}
+
+// The pacing timings are shortened for the whole package, in init.
+//
+// Not per test and not under sync.Once: a restoration runs on its own goroutine and outlives the
+// test that started it, so any write after the first test begins races with a run still reading
+// them. init runs before any test and before any such goroutine exists, which removes the race
+// rather than narrowing it. This package already has a TestMain, so that seat is taken.
+func init() {
+	restorationSettleTimeout = 60 * time.Millisecond
+	restorationPollInterval = 2 * time.Millisecond
+	associationWaitTimeout = 200 * time.Millisecond
+	enumerationWindow = 200 * time.Millisecond
+}
+
+func restoreQuickly(t *testing.T) {
+	t.Helper() // timings are set in init; the call is kept so each test says it depends on them
+}
+
+// A restoration works from the set of sessions that existed when the restart was observed. The run
+// that supersedes it must take its own snapshot: a session established between the two restarts
+// belongs to the incarnation now current, and one enumerated by the abandoned run may since have
+// gone. Reusing the earlier list would repair the wrong population.
+func TestTheSupersedingRunTakesItsOwnSnapshot(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.30"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+	restorationsInProgress.Delete(nodeIP)
+	defer restorationsInProgress.Delete(nodeIP)
+
+	before := sessionOn(t, "imsi-208930000000701", 1, nodeIP)
+
+	// A run is already under way for the earlier incarnation.
+	abandoned := &restorationRun{}
+	restorationsInProgress.Store(nodeIP, abandoned)
+
+	// The node restarts again, and a session appears that the abandoned run never saw.
+	after := sessionOn(t, "imsi-208930000000702", 2, nodeIP)
+	after.PFCPContext[nodeIP].RemoteSEID = 7777
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	if !abandoned.isSuperseded() {
+		t.Fatalf("precondition: the run in progress should have been superseded")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		after.SMLock.Lock()
+		picked := after.PFCPContext[nodeIP].RemoteSEID == 0
+		after.SMLock.Unlock()
+		if picked {
+			return // the superseding run enumerated it, so it took a fresh snapshot
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("a session that appeared after the abandoned run started was never re-issued; the " +
+		"superseding run reused the earlier snapshot and left it on an incarnation that is gone")
+	_ = before
+}
+
+// A session that has been released must not still read as active, or the control plane reports a
+// working service that does not exist -- the state this whole change exists to end.
+func TestAReleasedSessionDoesNotStillReadAsActive(t *testing.T) {
+	smContext := sessionOn(t, "imsi-208930000000703", 3, restarted)
+	if smContext.SMContextState == context.SmStateRelease {
+		t.Fatalf("precondition: the session should start active")
+	}
+
+	if err := releaseOneSession(smContext); err == nil {
+		t.Logf("release completed without error")
+	}
+
+	if smContext.SMContextState != context.SmStateRelease {
+		t.Errorf("state is %v after release, want %v; a session reported as active while carrying "+
+			"nothing is undiagnosable from the control plane", smContext.SMContextState, context.SmStateRelease)
+	}
+}
+
+// associatedUpfAt registers a UPF for the node in the associated state, which restoration requires
+// before it will issue anything: a session establishment sent while the association is down is
+// rejected, and a rejection is indistinguishable from a session the UPF will not accept.
+func associatedUpfAt(t *testing.T, nodeIP string) {
+	t.Helper()
+	upf := context.NewUPF(context.NewNodeID(nodeIP), nil)
+	upf.UPFStatus = context.AssociatedSetUpSuccess
+	upf.RecoveryTimeStamp = context.RecoveryTimeStamp{RecoveryTimeStamp: time.Now()}
+}
+
+// A node that is slow but willing must make the run take longer, not make it issue more at once.
+// The bound exists so a restarted UPF is not handed its whole population in one burst; a node that
+// answers slowly is exactly the case where a run that widened instead of waiting would do the most
+// damage, since the sessions already outstanding are the ones it is struggling with.
+func TestASlowNodeReducesThroughputRatherThanRaisingConcurrency(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.21"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+
+	// Three full waves, and an answer delay well inside the settle timeout so the node reads as slow
+	// rather than as refusing -- a refusing node is a different behaviour, tested separately.
+	const population = 24
+	const answerDelay = 25 * time.Millisecond
+	sessions := make([]*context.SMContext, 0, population)
+	for i := range population {
+		sessions = append(sessions, sessionOn(t, fmt.Sprintf("imsi-2089300000006%02d", i), int32(i+1), nodeIP))
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		firstSeen := make(map[*context.SMContext]time.Time)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			for _, smContext := range sessions {
+				smContext.SMLock.Lock()
+				if c, ok := smContext.PFCPContext[nodeIP]; ok && c.RemoteSEID == 0 {
+					seen, ok := firstSeen[smContext]
+					if !ok {
+						firstSeen[smContext] = time.Now()
+					} else if time.Since(seen) >= answerDelay {
+						c.RemoteSEID = 4242
+						delete(firstSeen, smContext)
+					}
+				}
+				smContext.SMLock.Unlock()
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	peak := int32(0)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			outstanding := int32(outstandingIn(sessions, nodeIP))
+			for {
+				current := atomic.LoadInt32(&peak)
+				if outstanding <= current || atomic.CompareAndSwapInt32(&peak, current, outstanding) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	start := time.Now()
+	restoreSessions(nodeID, nodeIP, &restorationRun{})
+	elapsed := time.Since(start)
+
+	if got := int(atomic.LoadInt32(&peak)); got > maxRestorationsInFlight {
+		t.Errorf("a slow node drew %d outstanding requests, bound is %d; the run widened instead of "+
+			"waiting, which is the opposite of what the bound is for", got, maxRestorationsInFlight)
+	}
+	// The waves cannot overlap, so the run cannot finish faster than the node answers. Checked at two
+	// waves rather than three to leave room for scheduling, while still being far more than a run
+	// that issued everything at once would take.
+	if floor := 2 * answerDelay; elapsed < floor {
+		t.Errorf("the run finished in %v against a node taking %v per wave; it cannot have waited for "+
+			"the waves it issued (expected at least %v)", elapsed, answerDelay, floor)
+	}
+}
+
+// A sweep that finds every session locked reports a fault. When this run displaced another, that is
+// not a fault -- the displaced run abandons at its next checkpoint but can still hold a session's
+// lock until then -- and reporting it as one sent a real diagnosis down the wrong path.
+func TestARunRecordsThatItDisplacedAnother(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.11")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+
+	restorationsInProgress.Store(nodeIP, &restorationRun{})
+	defer restorationsInProgress.Delete(nodeIP)
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	current, ok := restorationsInProgress.Load(nodeIP)
+	if !ok {
+		t.Fatalf("no restoration recorded for the node after a second restart")
+	}
+	run, ok := current.(*restorationRun)
+	if !ok {
+		t.Fatalf("what was recorded for the node is not a restoration run")
+	}
+	if !run.displacedAPriorRun {
+		t.Errorf("a run that displaced another did not record it; a locked-out sweep will be reported " +
+			"as a fault when it is two runs handing over")
+	}
+}
+
+// The converse: a first restart has displaced nothing, so a sweep that finds everything locked there
+// really is unexplained and must keep saying so.
+func TestAFirstRunRecordsThatItDisplacedNothing(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.12")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+	defer restorationsInProgress.Delete(nodeIP)
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	current, ok := restorationsInProgress.Load(nodeIP)
+	if !ok {
+		return // the run finished and removed itself; it displaced nothing either way
+	}
+	if run, ok := current.(*restorationRun); ok && run.displacedAPriorRun {
+		t.Errorf("a first restoration recorded that it displaced another")
+	}
+}
+
+// The wave loop must not be stoppable by a session's lock. SMLock is held across network calls
+// elsewhere in this codebase, so a blocking acquire here is an unbounded wait: on a cluster it hung
+// a run at 50 sessions, which never logged completion and left the population unrestored.
+func TestAWaveIsNotBlockedByASessionWhoseLockIsHeld(t *testing.T) {
+	nodeIP := "10.30.0.30"
+	held := sessionOn(t, "imsi-208930000000070", 1, nodeIP)
+	free := sessionOn(t, "imsi-208930000000071", 2, nodeIP)
+
+	held.SMLock.Lock()
+	defer held.SMLock.Unlock()
+
+	returned := make(chan waveOutcome, 1)
+	go func() { returned <- outcomeOf(held, nodeIP) }()
+
+	select {
+	case got := <-returned:
+		if got == waveUnanswered {
+			t.Errorf("a session whose lock could not be taken was reported unanswered; it would be " +
+				"released as unrestorable on evidence nobody looked at")
+		}
+		if got != waveUnknown {
+			t.Errorf("classified as %v, want waveUnknown -- nothing can be known about a session whose "+
+				"lock is held", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("classifying a session whose lock was held blocked; the wave loop cannot finish")
+	}
+	if got := outcomeOf(free, nodeIP); got == waveUnknown {
+		t.Errorf("a session whose lock was free could not be classified")
+	}
+}
+
+// One restart, seen on two exchanges, must produce one restoration. Both exchanges are meant to
+// reach this function -- the spec requires every path that can observe a restart to act on it -- so
+// the duplicate has to be recognised here rather than prevented by silencing a path.
+func TestTheSameRestartSeenTwiceStartsOneRestoration(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.40")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+	defer restorationsInProgress.Delete(nodeIP)
+
+	recovery := time.Now()
+	first := &restorationRun{recovery: recovery}
+	restorationsInProgress.Store(nodeIP, first)
+
+	RestoreSessionsOnUPF(nodeID, recovery)
+
+	current, ok := restorationsInProgress.Load(nodeIP)
+	if !ok {
+		t.Fatalf("no restoration recorded for the node")
+	}
+	if current != any(first) {
+		t.Errorf("the run in progress was replaced by a second one for the same restart; the two " +
+			"displace each other and at scale neither finishes")
+	}
+	if first.isSuperseded() {
+		t.Errorf("the run repairing this restart was abandoned on seeing the same restart again")
+	}
+}
+
+// A node that really has restarted again must still displace the run in progress, which is working
+// from an incarnation that no longer exists.
+func TestADifferentRestartStillSupersedes(t *testing.T) {
+	nodeID := *context.NewNodeID("10.30.0.41")
+	nodeIP := nodeID.ResolveNodeIdToIp().String()
+	defer restorationsInProgress.Delete(nodeIP)
+
+	first := &restorationRun{recovery: time.Now().Add(-time.Minute)}
+	restorationsInProgress.Store(nodeIP, first)
+
+	RestoreSessionsOnUPF(nodeID, time.Now())
+
+	if !first.isSuperseded() {
+		t.Errorf("a genuine second restart did not abandon the run repairing the first; it would " +
+			"re-install rules against an incarnation that has already discarded them")
+	}
+	current, _ := restorationsInProgress.Load(nodeIP)
+	if current == any(first) {
+		t.Errorf("the abandoned run is still recorded as the current one")
+	}
+}
+
+// "Nothing anchored here" and "nothing here could be looked at" are opposite outcomes, and only one
+// of them is good news. On a cluster at 20 sessions the sweep found every session locked, logged an
+// error saying so, and then logged that there was nothing to restore and set the unrestored gauge to
+// zero -- two adjacent lines telling opposite stories, with the metric agreeing with the wrong one.
+// A population that could not be examined is exactly as dead as before.
+func TestASweepThatCouldNotLookAtAnySessionDoesNotReportNothingToRestore(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.50"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+
+	locked := sessionOn(t, "imsi-208930000000080", 1, nodeIP)
+	locked.SMLock.Lock()
+	defer locked.SMLock.Unlock()
+
+	_, unexaminable, _ := enumerateWithRetry(nodeID, nodeIP, &restorationRun{})
+
+	if len(unexaminable) == 0 {
+		t.Fatalf("the sweep reported nothing unexaminable while a session's lock was held; the caller " +
+			"cannot then tell an empty node from one it could not examine")
+	}
+	if attributableTo(nodeIP, unexaminable) != 0 {
+		t.Errorf("a session never seen anchored here was attributed to this node; a UPF with nothing on " +
+			"it would report sessions it does not have")
+	}
+	rememberAnchored(nodeIP, []*context.SMContext{locked})
+	if attributableTo(nodeIP, unexaminable) != 1 {
+		t.Errorf("a session last seen anchored here was not attributed to it, so a population stranded " +
+			"behind held locks would be reported as absent")
+	}
+}
+
+// The converse must keep working: a node with nothing on it really has nothing to restore, and must
+// not be reported as a population that could not be examined.
+func TestASweepOfAnEmptyNodeReportsNothingLocked(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.51"
+	nodeID := *context.NewNodeID(nodeIP)
+	associatedUpfAt(t, nodeIP)
+
+	anchored, unexaminable, _ := enumerateWithRetry(nodeID, nodeIP, &restorationRun{})
+
+	if len(anchored) != 0 || len(unexaminable) != 0 {
+		t.Errorf("an empty node reported %d anchored and %d unexaminable; it should report neither",
+			len(anchored), len(unexaminable))
+	}
+}
+
+// Restoration sends establishments and waits on the remote identifier, not on the response channel,
+// so the responses it causes are never taken. The channel holds one value, and
+// HandlePfcpSessionEstablishmentResponse sends into it while holding SMLock -- so the second
+// restoration of a session finds it full, the handler's send blocks forever, and the session's lock
+// is never released again. On a cluster that left 20 of 20 sessions permanently unrestorable.
+func TestReissueLeavesRoomForTheResponseItWillCause(t *testing.T) {
+	nodeIP := "10.30.0.60"
+	smContext := sessionOn(t, "imsi-208930000000090", 1, nodeIP)
+
+	// Stand in for the response to a previous restoration, which nothing consumed.
+	smContext.SBIPFCPCommunicationChan <- context.SessionEstablishSuccess
+
+	reissue(smContext, nodeIP)
+
+	// The handler sends without selecting, so the only thing that keeps it from blocking is room in
+	// the buffer. A non-blocking send standing in for it must therefore succeed.
+	select {
+	case smContext.SBIPFCPCommunicationChan <- context.SessionEstablishSuccess:
+	default:
+		t.Errorf("no room for the response this establishment will cause; the handler sends while " +
+			"holding SMLock, so it would block there forever and the session could never be restored again")
+	}
+}
+
+// A wave in which nothing could be examined must not read as a wave that succeeded. The check used
+// to skip sessions whose lock it could not take and then treat the empty result as "all answered",
+// so a batch that was entirely busy was counted as restored without anything having been looked at.
+func TestAWaveWhereNothingCanBeExaminedReportsNoneRestored(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.70"
+	a := sessionOn(t, "imsi-208930000000100", 1, nodeIP)
+	b := sessionOn(t, "imsi-208930000000101", 2, nodeIP)
+	a.SMLock.Lock()
+	b.SMLock.Lock()
+	defer a.SMLock.Unlock()
+	defer b.SMLock.Unlock()
+
+	settled := settleWave([]*context.SMContext{a, b}, nodeIP)
+
+	if settled.answered != 0 {
+		t.Errorf("%d session(s) counted as restored, but neither could be examined", settled.answered)
+	}
+	if settled.unknown != 2 {
+		t.Errorf("%d session(s) reported as unexaminable, want 2", settled.unknown)
+	}
+	if len(settled.unanswered) != 0 {
+		t.Errorf("%d session(s) would be released, on evidence nobody could gather", len(settled.unanswered))
+	}
+}
+
+// The set a wave returns for release can only contain sessions the wave was given. The wave loop
+// passes it only what reissue actually sent, so a session that was skipped -- busy, purged, without
+// a tunnel -- cannot be torn down on the strength of a silence about a request never made.
+func TestAWaveNeverReturnsASessionItWasNotGiven(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.71"
+	sent := sessionOn(t, "imsi-208930000000102", 1, nodeIP)
+	sent.PFCPContext[nodeIP].RemoteSEID = 0
+	skipped := sessionOn(t, "imsi-208930000000103", 2, nodeIP)
+	skipped.PFCPContext[nodeIP].RemoteSEID = 0
+
+	settled := settleWave([]*context.SMContext{sent}, nodeIP)
+
+	for _, s := range settled.unanswered {
+		if s == skipped {
+			t.Fatalf("a session the wave was never given came back in the release set")
+		}
+	}
+	if len(settled.unanswered) != 1 || settled.unanswered[0] != sent {
+		t.Errorf("expected exactly the session that was sent, got %d", len(settled.unanswered))
+	}
+}
+
+// A session that has moved off this node in the meantime is neither restored nor unrestorable. It
+// used to be indistinguishable from one the node had answered, which inflated the restored count.
+func TestASessionThatLeftTheNodeIsNotCountedAsRestored(t *testing.T) {
+	restoreQuickly(t)
+	nodeIP := "10.30.0.72"
+	gone := sessionOn(t, "imsi-208930000000104", 1, "10.30.0.99")
+
+	settled := settleWave([]*context.SMContext{gone}, nodeIP)
+
+	if settled.answered != 0 {
+		t.Errorf("a session anchored elsewhere was counted as restored on %s", nodeIP)
+	}
+	if settled.gone != 1 {
+		t.Errorf("gone=%d, want 1", settled.gone)
+	}
+}
+
+// releaseOneSession recovers from panics, which means a lock leaked on a panicking path is invisible
+// -- the release merely reports an error, and every later sweep silently finds that session
+// unexaminable for the rest of the process's life. ChangeState indexes into the data path pool and
+// panics on a context without the entry it expects, so this is reachable, and it happened once while
+// this code was being written.
+func TestAPanicWhileReleasingDoesNotLeaveTheSessionLocked(t *testing.T) {
+	nodeIP := "10.30.0.80"
+	smContext := sessionOn(t, "imsi-208930000000110", 1, nodeIP)
+
+	// ChangeState only walks the data path pool when the session is or becomes active, and this pool
+	// has no entry at the index it reaches for.
+	smContext.SMLock.Lock()
+	smContext.SMContextState = context.SmStateActive
+	smContext.SMLock.Unlock()
+
+	if err := releaseOneSession(smContext); err == nil {
+		t.Errorf("the release reported success although it panicked part-way")
+	}
+
+	if !smContext.SMLock.TryLock() {
+		t.Fatalf("the session's lock was not released; every later sweep would skip it as unexaminable " +
+			"and it could never be restored or released again")
+	}
+	smContext.SMLock.Unlock()
+}
+
+// outstandingIn observes a run in progress from the outside. The wave loop itself uses settleWave,
+// which distinguishes states this does not.
+func outstandingIn(batch []*context.SMContext, nodeIP string) int {
+	outstanding := 0
+	for _, smContext := range batch {
+		if outcomeOf(smContext, nodeIP) == waveUnanswered {
+			outstanding++
+		}
+	}
+	return outstanding
+}

--- a/producer/restoration_wire_test.go
+++ b/producer/restoration_wire_test.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/omec-project/nas/v2/nasMessage"
+	"github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/factory"
+	"github.com/omec-project/smf/pfcp/udp"
+	"github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+)
+
+// The whole mechanism rests on one thing: a restored session must be sent as a session
+// ESTABLISHMENT, not a modification. A restarted UPF holds no session, so a modification addressed
+// to a session identifier it never issued is either rejected or, worse, applied to unrelated state.
+//
+// Nothing else in the suite looks at what actually goes on the wire, so this stands up a PFCP
+// socket for the SMF and a listener standing in for the UPF, and reads the message type off it.
+func TestARestoredSessionIsSentAsAnEstablishmentNotAModification(t *testing.T) {
+	nativeDatapath(t)
+	upfConn, upfPort := listenLoopback(t)
+	startSmfPfcpSocket(t)
+
+	upf := context.NewUPF(context.NewNodeID("127.0.0.1"), nil)
+	upf.UPFStatus = context.AssociatedSetUpSuccess
+	upf.Port = upfPort
+	upf.RecoveryTimeStamp = context.RecoveryTimeStamp{RecoveryTimeStamp: time.Now()}
+	// The N3 interface the RAN was told to send to. Without it the tunnel cannot be pinned.
+	upf.N3Interfaces = []context.UPFInterfaceInfo{{
+		NetworkInstance:       "internet",
+		IPv4EndPointAddresses: []net.IP{net.ParseIP("192.168.252.3")},
+	}}
+
+	smContext, wantPDRID, wantTEID := sessionWithDataPath(t, "imsi-208930000000901", 1, upf)
+
+	// A session that is currently established: the UPF has issued an identifier for it. Left as it
+	// is, the activation path would send a modification.
+	pfcpCtx := smContext.PFCPContext["127.0.0.1"]
+	pfcpCtx.RemoteSEID = 0xBEEF
+
+	if !reissue(smContext, "127.0.0.1") {
+		t.Fatalf("the session was not re-issued")
+	}
+
+	msg := readPfcp(t, upfConn)
+	if got, want := msg.MessageType(), message.MsgTypeSessionEstablishmentRequest; got != want {
+		t.Fatalf("the restarted UPF received message type %d, want %d (session establishment). "+
+			"A modification names a session the restarted UPF never created.", got, want)
+	}
+
+	// The rules go back with the identifiers the SMF already holds. They mean something to a UPF
+	// only while it holds the rules they name, and a restarted one holds none, so carrying them
+	// over is both safe and what keeps every existing reference to a rule valid.
+	establishment, ok := msg.(*message.SessionEstablishmentRequest)
+	if !ok {
+		t.Fatalf("unexpected message shape %T", msg)
+	}
+	if len(establishment.CreatePDR) == 0 {
+		t.Fatalf("the establishment carried no Create PDR, so nothing was re-installed")
+	}
+	pdrID, err := establishment.CreatePDR[0].PDRID()
+	if err != nil {
+		t.Fatalf("reading the PDR ID back: %v", err)
+	}
+	if pdrID != wantPDRID {
+		t.Errorf("the re-installed PDR is %d, want %d; restoration renumbered a rule it should have "+
+			"carried over, leaving every reference the SMF holds pointing at the old value", pdrID, wantPDRID)
+	}
+
+	// The uplink tunnel must be named, not re-chosen. If the CHOOSE flag is still set the UPF
+	// allocates a second TEID, the RAN is never told, and every uplink packet keeps arriving on the
+	// old one and misses the rule table -- which is what the cluster showed.
+	pdi, err := establishment.CreatePDR[0].PDI()
+	if err != nil {
+		t.Fatalf("reading the PDI back: %v", err)
+	}
+	var fteid *ie.IE
+	for _, child := range pdi {
+		if child.Type == ie.FTEID {
+			fteid = child
+		}
+	}
+	if fteid == nil {
+		t.Fatalf("the re-installed PDR carries no F-TEID, so the UPF has nothing to match uplink on")
+	}
+	f, err := fteid.FTEID()
+	if err != nil {
+		t.Fatalf("parsing the F-TEID: %v", err)
+	}
+	if f.HasCh() {
+		t.Errorf("the F-TEID still has the CHOOSE flag set, so the restarted UPF will allocate a new " +
+			"tunnel the RAN knows nothing about")
+	}
+	if f.TEID != wantTEID {
+		t.Errorf("the re-installed tunnel is TEID %#x, want %#x — the one the RAN is sending on", f.TEID, wantTEID)
+	}
+}
+
+// nativeDatapath selects the PFCP datapath rather than the adapter, which would post the message to
+// an HTTP endpoint instead of putting it on the wire.
+func nativeDatapath(t *testing.T) {
+	t.Helper()
+	enabled := false
+	factory.SmfConfig = factory.Config{
+		Configuration: &factory.Configuration{
+			KafkaInfo:        factory.KafkaInfo{EnableKafka: &enabled},
+			EnableUpfAdapter: false,
+		},
+	}
+}
+
+func listenLoopback(t *testing.T) (*net.UDPConn, uint16) {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("standing in for the UPF: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn, uint16(conn.LocalAddr().(*net.UDPAddr).Port)
+}
+
+// startSmfPfcpSocket gives the SMF a real socket to send from, which the send path takes from the
+// package-level server rather than opening per message.
+func startSmfPfcpSocket(t *testing.T) {
+	t.Helper()
+	self := context.SMF_Self()
+	free, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 0})
+	if err != nil {
+		t.Fatalf("reserving a port for the SMF: %v", err)
+	}
+	port := free.LocalAddr().(*net.UDPAddr).Port
+	free.Close()
+
+	self.CPNodeID = *context.NewNodeID("127.0.0.1")
+	self.PFCPPort = port
+	udp.Run(func(*udp.Message) {})
+	time.Sleep(50 * time.Millisecond) // let the listener bind before anything is sent
+}
+
+func readPfcp(t *testing.T, conn *net.UDPConn) message.Message {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+		t.Fatalf("setting a read deadline: %v", err)
+	}
+	buf := make([]byte, 4096)
+	n, _, err := conn.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("the restarted UPF received nothing: %v", err)
+	}
+	msg, err := message.Parse(buf[:n])
+	if err != nil {
+		t.Fatalf("parsing what the UPF received: %v", err)
+	}
+	return msg
+}
+
+// sessionWithDataPath builds a session with one activated data path anchored on the given UPF, so
+// the activation path has rules to send.
+func sessionWithDataPath(t *testing.T, supi string, psi int32, upf *context.UPF) (*context.SMContext, uint16, uint32) {
+	t.Helper()
+	pdr, err := upf.AddPDR()
+	if err != nil {
+		t.Fatalf("allocating a PDR: %v", err)
+	}
+	// What ActivateUpLinkTunnel builds: the CHOOSE flag set, asking the UPF to allocate the tunnel.
+	// Restoration has to turn this into a named tunnel, and a bare PDR would not exercise that.
+	pdr.PDI.SourceInterface = context.SourceInterface{InterfaceValue: context.SourceInterfaceAccess}
+	pdr.PDI.LocalFTeid = &context.FTEID{Ch: true}
+
+	smContext := context.NewSMContext(supi, psi)
+	// The N3 address is resolved per session type, the same way the N2 setup resolves it.
+	smContext.SelectedPDUSessionType = nasMessage.PDUSessionTypeIPv4
+	smContext.Tunnel = &context.UPTunnel{
+		DataPathPool: context.DataPathPool{
+			1: &context.DataPath{
+				Activated:     true,
+				IsDefaultPath: true,
+				FirstDPNode: &context.DataPathNode{
+					UPF:          upf,
+					UpLinkTunnel: &context.GTPTunnel{TEID: 0x1234, PDR: map[string]*context.PDR{"default": pdr}},
+				},
+			},
+		},
+	}
+	smContext.SMLock.Lock()
+	smContext.PFCPContext[upf.NodeID.ResolveNodeIdToIp().String()] = &context.PFCPSessionContext{
+		NodeID:    upf.NodeID,
+		LocalSEID: 4321,
+	}
+	smContext.SMLock.Unlock()
+	return smContext, pdr.PDRID, 0x1234
+}


### PR DESCRIPTION
## What

When a UPF restarts, the SMF keeps a session record describing rules the UPF no longer holds, and
nothing re-installs them. The subscriber's data path is gone until the UE re-attaches or the session
times out.

Nothing says so. The session reads as active, the PFCP association re-establishes and looks healthy,
heartbeats continue, and every counter is normal. That silence is the substance of the defect: the
only symptom is a subscriber with no service and no diagnostic anywhere that distinguishes it from a
working system.

This restores those sessions from the record the SMF already holds.

## Why the SMF's record is enough

The UPF has forgotten its rules; this SMF has not. Its record is therefore the description of what
each session needs, and re-installing from it is the whole of the repair. Identifiers are carried
over unchanged — they mean something to a UPF only while it holds the rules they name, and a
restarted one holds none.

## What it does

- **Detects the restart on every exchange that can reveal one** — heartbeat response, association
  setup request and association setup response on the native path, and the two the adapter path has.
  Before this, each of those sites noticed the changed timestamp and then did nothing with it: the
  heartbeat marked the UPF unassociated and left a `TODO: Session cleanup required`, and the two
  association sites simply overwrote the held value. Each now compares *before* overwriting, because
  afterwards the evidence is gone and what replaces it is the state that hides it.
- **Compares recovery timestamps at second granularity, with `Unix()`.** A PFCP recovery timestamp
  carries whole seconds and nothing finer, and comparing `time.Time` values with `!=` also compares
  their monotonic reading and location — so two timestamps describing the same second could differ
  for reasons having nothing to do with the UPF.
- **Identifies a restart by the recovery state it carries**, so the same restart observed on two
  exchanges seconds apart starts one restoration rather than two that displace each other.
- **Re-issues each anchored session as an establishment**, not a modification, which is the correct
  message for a node holding no session.
- **Paces the work in waves** (8 outstanding) so a just-started UPF is not handed its whole
  population at once, and stops rather than hammering a node that answers nothing.
- **Releases sessions the UPF will not accept.** A released session is a fact the rest of the system
  can act on; a session reported active while forwarding nothing is undiagnosable from the control
  plane.
- **Adds two metrics**: `smf_upf_restoration_sessions_total{id,upf,outcome}` and
  `smf_upf_unrestored_sessions{id,upf}`. Labelled by UPF, never by subscriber.

A peer that merely stopped answering is deliberately *not* treated as one that restarted. A liveness
timeout or a transition to unassociated means the SMF cannot currently reach the UPF, not that the
UPF lost its state — and re-installing over working forwarding state would create duplicates. Only
changed recovery state triggers restoration.

## Measured

On a single-node deployment, with recovery verified by traffic rather than by the PFCP cause:

| scenario | result |
|---|---|
| 1 UE, consecutive restarts | service back 27 s and 33 s after the rollout began, same address |
| 20 UEs, six consecutive restarts | 20/20 forwarding every round, 22–48 s |
| ~50 UEs, three consecutive restarts | `50 restored, 0 not restored` each round, ~30 s |

Across the six 20-UE rounds the control plane recorded 12 restart detections for 6 restarts (each
restart is visible on two exchanges), 6 recognised as the same restart, **0 restorations displaced,
0 inconclusive sweeps, 6 completions**. In the larger run 49 UEs were attached at the start and a
50th joined during it, so the SMF anchored 50 sessions; the data path went from 33 of 49 tunnels
forwarding *before* the restart to 50 after — the restoration also repaired sessions that were
already dead.

## Three defects that only appear at scale

Recording these because each passed single-UE testing and a green suite, and they are the reason the
wave accounting is shaped the way it is:

1. **Restoration overwrote a session still being established.** Re-issuing its rules cleared the
   CHOOSE flag and pinned the SMF's placeholder UE address before the UPF had chosen one, leaving the
   subscriber outside the address pool with no downlink. Sessions the node has never acknowledged are
   now excluded.
2. **Every restart fired the restoration twice**, because the heartbeat path detected the restart and
   the re-association then detected the same one. At ~50 sessions the two runs displaced each other,
   the last never completed, and the population was left part-restored.
3. **A permanent deadlock.** `SBIPFCPCommunicationChan` holds one value and
   `HandlePfcpSessionEstablishmentResponse` sends into it while holding `SMLock`. Restoration waits on
   the remote identifier rather than that channel, so its responses accumulated; the second
   restoration of a session found the channel full and parked the PFCP dispatcher there permanently
   with the session's lock held. Diagnosed from a goroutine dump: 20 of 20 sessions locked, 20
   goroutines in `chan send`. `reissue` now takes back the unconsumed response before re-issuing.

## Known limits

- **Two detection paths are covered by unit tests only.** The association *setup request* path is
  unreachable on the deployment tested: that UPF never initiates an association (its own log shows
  the request arriving *from* the SMF), and over an hour the SMF handled 0 requests against 11
  responses. Likewise a second restart arriving *during* a restoration — restorations now complete in
  well under a second, so no externally triggerable interval lands inside one.
- **On the adapter datapath the rule send happens under `SMLock`**, where it is an HTTP POST bounded
  at 30 s rather than a UDP write. Not fixed here: it needs the rule graph snapshotting, and it is
  unreachable with `enableUPFAdapter: false`. Recorded rather than left implicit.
- **`HandlePfcpSessionModificationResponse` writes `PFCPContext` without `SMLock`** via
  `AddPDUSessionAnchorAndULCL`, while the same function is called *with* the lock from the
  establishment handler. That is pre-existing and belongs to the ULCL feature, so it is not touched
  here — but this change's sweep is a lock-abiding reader of that map, and the divergence is worth a
  separate fix.

## Tests

Unit tests cover each detection path, the enumeration's exclusions, the wave bound and its behaviour
against a slow node, supersede, the release path, and a loopback PFCP exchange that stands in for the
UPF and asserts the restored session arrives as a Session Establishment Request carrying the original
PDR ID, the original TEID, and an F-TEID with the CHOOSE flag cleared.

Each fix in this series was mutation-verified — reverting the fix makes its test fail — because
several of these defects were originally masked by tests that agreed with the code.

`go test ./... -race` passes across all 15 packages. `golangci-lint run` and `golangci-lint fmt
--diff` are both clean under the version CI pins (v2.11.3), checked in a linux/amd64 container.

Found in production and tracked internally; the symptom there was exactly the silent one described
at the top — a subscriber with no data path and a control plane reporting health.
