### PR TITLE
Stop discarding the ProblemDetails the NRF sent on a subscription failure

### DIFF
--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -748,9 +748,11 @@ func SendCreateSubscription(nrfUri string, nrfSubscriptionData models.Subscripti
 		return nrfSubData, nil, nil
 	} else if res != nil {
 		// Logged for every error response now, not only for the ones the removed guard let
-		// through. The message was already true in both cases, and a failed subscription is
-		// worth a line either way.
-		logger.ConsumerLog.Errorf("SendCreateSubscription received error response: %v", res.Status)
+		// through. Warn rather than Error: with the guard gone, a response whose body decodes is
+		// returned to the caller as problem details and a nil error, so the caller decides whether
+		// that is an error and reports it. Logging it as one here would contradict the nil error
+		// and duplicate the caller's own line.
+		logger.ConsumerLog.Warnf("SendCreateSubscription received error response: %v", res.Status)
 		if problem, handledErr := util.HandleOpenAPIError(err); problem != nil {
 			return nrfSubData, problem, nil
 		} else if handledErr != nil {

--- a/consumer/nf_management.go
+++ b/consumer/nf_management.go
@@ -747,10 +747,10 @@ func SendCreateSubscription(nrfUri string, nrfSubscriptionData models.Subscripti
 	if err == nil {
 		return nrfSubData, nil, nil
 	} else if res != nil {
-		if res.Status != err.Error() {
-			logger.ConsumerLog.Errorf("SendCreateSubscription received error response: %v", res.Status)
-			return nrfSubData, nil, err
-		}
+		// Logged for every error response now, not only for the ones the removed guard let
+		// through. The message was already true in both cases, and a failed subscription is
+		// worth a line either way.
+		logger.ConsumerLog.Errorf("SendCreateSubscription received error response: %v", res.Status)
 		if problem, handledErr := util.HandleOpenAPIError(err); problem != nil {
 			return nrfSubData, problem, nil
 		} else if handledErr != nil {
@@ -781,9 +781,9 @@ func SendRemoveSubscription(subscriptionId string) (problemDetails *models.Probl
 	if err == nil {
 		return nil, nil
 	} else if res != nil {
-		if res.Status != err.Error() {
-			return nil, openapi.ReportError("RemoveSubscription received error response: %s", res.Status)
-		}
+		// The status the removed guard reported is still carried: for a response whose body
+		// decoded, it is in the ProblemDetails returned below, and for one named by no arm the
+		// client leaves RawError set to the status, which HandleOpenAPIError passes back as is.
 		if problem, handledErr := util.HandleOpenAPIError(err); problem != nil {
 			return problem, nil
 		} else if handledErr != nil {

--- a/consumer/nf_subscription_error_test.go
+++ b/consumer/nf_subscription_error_test.go
@@ -51,15 +51,20 @@ func nrfRejecting(t *testing.T) *httptest.Server {
 	svr.EnableHTTP2 = true
 	svr.StartTLS()
 	newNrfNFManagementHTTPClient = func() *http.Client { return svr.Client() }
-	t.Cleanup(func() {
-		newNrfNFManagementHTTPClient = originalHTTPClientFactory
-		svr.Close()
-	})
-
 	if err := factory.InitConfigFactory("../config/smfcfg.yaml"); err != nil {
 		t.Fatalf("could not read the example configuration file: %v", err)
 	}
+
+	// SendRemoveSubscription reads the NRF URI from the process-wide SMF context rather than
+	// taking it as an argument, so it is set here - and restored, because otherwise a later test
+	// in this package inherits a URL whose server has already been closed.
+	originalNrfURI := smfContext.SMF_Self().NrfUri
 	smfContext.SMF_Self().NrfUri = svr.URL
+	t.Cleanup(func() {
+		smfContext.SMF_Self().NrfUri = originalNrfURI
+		newNrfNFManagementHTTPClient = originalHTTPClientFactory
+		svr.Close()
+	})
 
 	return svr
 }

--- a/consumer/nf_subscription_error_test.go
+++ b/consumer/nf_subscription_error_test.go
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package consumer
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/omec-project/openapi/v2/models"
+	smfContext "github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/factory"
+)
+
+const (
+	subErrTitle  = "Subscription rejected"
+	subErrDetail = "the NRF does not accept subscriptions for this NF type"
+	subErrCause  = "SUBSCRIPTION_NOT_ALLOWED"
+)
+
+// nrfRejecting stands up an NRF that answers every request with a 403 carrying a conformant
+// ProblemDetails, which is the shape the generated client decodes into GenericOpenAPIError.RawModel
+// and the shape the removed guard used to discard.
+func nrfRejecting(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	body, err := json.Marshal(models.ProblemDetails{
+		Title:  ptr(subErrTitle),
+		Detail: ptr(subErrDetail),
+		Cause:  ptr(subErrCause),
+		Status: ptrInt32(http.StatusForbidden),
+	})
+	if err != nil {
+		t.Fatalf("marshalling the problem details: %v", err)
+	}
+
+	originalHTTPClientFactory := newNrfNFManagementHTTPClient
+	svr := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/nnrf-nfm/v1/subscriptions") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusForbidden)
+		if _, writeErr := w.Write(body); writeErr != nil {
+			t.Errorf("writing the response body: %v", writeErr)
+		}
+	}))
+	svr.EnableHTTP2 = true
+	svr.StartTLS()
+	newNrfNFManagementHTTPClient = func() *http.Client { return svr.Client() }
+	t.Cleanup(func() {
+		newNrfNFManagementHTTPClient = originalHTTPClientFactory
+		svr.Close()
+	})
+
+	if err := factory.InitConfigFactory("../config/smfcfg.yaml"); err != nil {
+		t.Fatalf("could not read the example configuration file: %v", err)
+	}
+	smfContext.SMF_Self().NrfUri = svr.URL
+
+	return svr
+}
+
+func ptr(s string) *string { return &s }
+
+func ptrInt32(i int32) *int32 { return &i }
+
+// assertProblemDetails is the whole point of the change: the NRF's stated reason reaches the
+// caller instead of being replaced by a bare status.
+func assertProblemDetails(t *testing.T, problem *models.ProblemDetails, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("err = %v, want nil: a 403 whose body decoded is a problem the caller can read, "+
+			"not a transport failure", err)
+	}
+	if problem == nil {
+		t.Fatal("problemDetails = nil, want the ProblemDetails the NRF sent; the response body " +
+			"decoded and was then discarded, which is the defect this test pins")
+	}
+	if got := problem.GetTitle(); got != subErrTitle {
+		t.Errorf("Title = %q, want %q", got, subErrTitle)
+	}
+	if got := problem.GetDetail(); got != subErrDetail {
+		t.Errorf("Detail = %q, want %q", got, subErrDetail)
+	}
+	if got := problem.GetCause(); got != subErrCause {
+		t.Errorf("Cause = %q, want %q", got, subErrCause)
+	}
+	if got := problem.GetStatus(); got != http.StatusForbidden {
+		t.Errorf("Status = %d, want %d", got, http.StatusForbidden)
+	}
+}
+
+// The guard fired precisely when there was something to read. The generated client replaces its
+// error string with FormatErrorMessage(status, model) as soon as a body decodes, so for a decoded
+// ProblemDetails err.Error() never equals res.Status - and the comparison then threw the model away
+// in favour of a bare status, on the one path where the NRF had explained itself.
+func TestSendCreateSubscriptionReturnsTheProblemDetails(t *testing.T) {
+	svr := nrfRejecting(t)
+
+	_, problem, err := SendCreateSubscription(svr.URL, models.SubscriptionData{})
+
+	assertProblemDetails(t, problem, err)
+}
+
+func TestSendRemoveSubscriptionReturnsTheProblemDetails(t *testing.T) {
+	nrfRejecting(t)
+
+	problem, err := SendRemoveSubscription("subscription-id")
+
+	assertProblemDetails(t, problem, err)
+}


### PR DESCRIPTION
## The defect

Both NRF subscription paths in `consumer/nf_management.go` compared `res.Status` against
`err.Error()` and returned early if they differed:

```go
if res.Status != err.Error() {
	return nil, openapi.ReportError("RemoveSubscription received error response: %s", res.Status)
}
if problem, handledErr := util.HandleOpenAPIError(err); problem != nil {
```

The generated client replaces its error string with `FormatErrorMessage(status, model)` as soon as a
body decodes, and that appends whatever the model's `Title` and `Detail` hold. `ProblemDetails` has
both, so the formatted message never equals the bare status. **The comparison therefore failed
precisely when a model had been decoded** — it discarded the NRF's stated reason on the one path
where the NRF had explained itself, and passed through only when there was nothing to read.

Both callers of `SendRemoveSubscription` (`callback/api_nf_subscribe_notify.go` and
`producer/callback.go`) already distinguish `problemDetails` from `err` and log each, so the reason
was theirs to report and never arrived.

## Why removing the guard loses nothing

- For a response whose body decoded, the status is in the `ProblemDetails` now returned.
- For a status named by no arm in the generated client, `RawError` is left as the status and
  `RawModel` is nil, so `HandleOpenAPIError` returns the error unchanged. That path never took the
  guard in the first place — the two strings were equal.

`HandleOpenAPIError` needed no change, which was worth checking rather than assuming: it handles
`models.ProblemDetails` and `*models.ProblemDetails` only, and every error status of both
`CreateSubscription` and `RemoveSubscription` decodes `ProblemDetails`. Neither reaches the
`ExtProblemDetails` shape that needed a wider accessor in the AMF.

The `SendCreateSubscription` log moves out of the removed branch rather than going with it: the
message was true in both cases, and a failed subscription is worth a line.

## Tests

New — neither function had one. Each drives the real function against an NRF returning a conformant
403 and asserts the title, detail, cause and status reach the caller with no error.

Mutation-verified: with the guards restored, both fail, reporting `problemDetails = nil` and the
formatted message in `err`.

## Provenance

Same defect and same fix as #800, which had seven sites of this shape in the AMF. These two were
found by looking for the class rather than the instance, so the PCF's three sites are covered by a
separate PR in that repository.

## Verification

`go test -race ./... -count=1`, `staticcheck` v0.8.1, `golangci-lint` v2.13.2 (in Docker, with the
repo config), `gci` v0.14.0, `gofmt`, `gofumpt` and `reuse lint` (156/156) are all clean. The commit
was extracted into a clean tree and re-checked there, not only in the working tree.

## Note for a reader of the file

`SendCreateSubscription` has no caller in the tree. That is pre-existing and left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyNr6vp6JaxxzPyVcuHXTf
