### PR TITLE
Echo the request's PTI in the PDU session establishment and release rejects

### DIFF
--- a/producer/n1n2_data_handler.go
+++ b/producer/n1n2_data_handler.go
@@ -163,6 +163,11 @@ func HandleUpdateN1Msg(txn *transaction.Transaction, response *models.UpdateSmCo
 			smContext.SubPduSessLog.Infof("PDUSessionSMContextUpdate, N1 Msg PDU Session Release Request received")
 			pduSessIDRelReq := int32(m.PDUSessionReleaseRequest.GetPDUSessionID())
 			smContext.SubPduSessLog.Debugln("PDU Session ID in Rel Req:", pduSessIDRelReq)
+			// Record the procedure transaction identity before the PDU session id is compared: the
+			// mismatch branch answers with a release reject built from the SM context but never
+			// reaches HandlePDUSessionReleaseRequest, which is otherwise the only place it is
+			// stored, so the reject would carry an identity the UE cannot match to its request.
+			smContext.Pti = m.PDUSessionReleaseRequest.GetPTI()
 			pduSessIDSmCxt := smContext.PDUSessionID
 			smContext.SubPduSessLog.Debugln("PDU Session ID in SM Context:", pduSessIDSmCxt)
 			if smContext.SMContextState != context.SmStateActive {

--- a/producer/pdu_session.go
+++ b/producer/pdu_session.go
@@ -159,6 +159,13 @@ func HandlePDUSessionSMContextCreate(eventData interface{}) error {
 		return fmt.Errorf("GsmMsgDecodeError")
 	}
 
+	// Record the procedure transaction identity as soon as the request is decoded, because the
+	// reject builders read it from the SM context and several refusals below are raised before
+	// HandlePDUSessionEstablishmentRequest, which is otherwise the only place it is stored. A
+	// rejection carrying an unassigned PTI is one the UE must ignore per TS 24.501 clause 7.3.1,
+	// UE procedures item e), so those refusals would reach the UE and be discarded.
+	smContext.Pti = m.PDUSessionEstablishmentRequest.GetPTI()
+
 	createData, _ := request.GetJsonDataOk()
 
 	// Create SM context

--- a/producer/reject_pti_test.go
+++ b/producer/reject_pti_test.go
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: 2026 Forsway Scandinavia AB
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/omec-project/nas/v2"
+	"github.com/omec-project/nas/v2/nasMessage"
+	"github.com/omec-project/openapi/v2"
+	"github.com/omec-project/openapi/v2/models"
+	smf_context "github.com/omec-project/smf/context"
+	"github.com/omec-project/smf/msgtypes/svcmsgtypes"
+	"github.com/omec-project/smf/smferrors"
+	"github.com/omec-project/smf/transaction"
+	"github.com/omec-project/util/httpwrapper"
+)
+
+// requestPti is the procedure transaction identity the simulated UE allocates for its request.
+// It is deliberately neither 0 nor 1: 0 is the value the defect these tests guard against
+// produced, and 1 is what the nasTestpacket builders hardcode, so a test asserting either could
+// pass by accident.
+const requestPti uint8 = 0x27
+
+// unservedDnn is not configured anywhere, so RetrieveDnnInformation returns nil for it and the
+// establishment is refused at the first branch of HandlePDUSessionSMContextCreate - before the
+// request is parsed, and without needing UDM, PCF or UPF.
+const unservedDnn = "notserved"
+
+func encodeEstablishmentRequest(t *testing.T, pduSessionID, pti uint8) []byte {
+	t.Helper()
+
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionEstablishmentRequest)
+
+	request := nasMessage.NewPDUSessionEstablishmentRequest(0)
+	request.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	request.SetMessageType(nas.MsgTypePDUSessionEstablishmentRequest)
+	request.SetPDUSessionID(pduSessionID)
+	request.SetPTI(pti)
+	request.SetMaximumDataRatePerUEForUserPlaneIntegrityProtectionForDownLink(0xff)
+	request.SetMaximumDataRatePerUEForUserPlaneIntegrityProtectionForUpLink(0xff)
+	m.PDUSessionEstablishmentRequest = request
+
+	payload := new(bytes.Buffer)
+	if err := m.GsmMessageEncode(payload); err != nil {
+		t.Fatalf("could not encode PDU session establishment request: %v", err)
+	}
+	return payload.Bytes()
+}
+
+func encodeReleaseRequest(t *testing.T, pduSessionID, pti uint8) []byte {
+	t.Helper()
+
+	m := nas.NewMessage()
+	m.GsmMessage = nas.NewGsmMessage()
+	m.GsmHeader.SetMessageType(nas.MsgTypePDUSessionReleaseRequest)
+
+	request := nasMessage.NewPDUSessionReleaseRequest(0)
+	request.SetExtendedProtocolDiscriminator(nasMessage.Epd5GSSessionManagementMessage)
+	request.SetMessageType(nas.MsgTypePDUSessionReleaseRequest)
+	request.SetPDUSessionID(pduSessionID)
+	request.SetPTI(pti)
+	m.PDUSessionReleaseRequest = request
+
+	payload := new(bytes.Buffer)
+	if err := m.GsmMessageEncode(payload); err != nil {
+		t.Fatalf("could not encode PDU session release request: %v", err)
+	}
+	return payload.Bytes()
+}
+
+// n1SmMessageFile mirrors what the AMF's multipart request delivers: the N1 SM message arrives as
+// a file, which the producer consumes with io.ReadAll, so it has to be written and rewound rather
+// than passed as bytes.
+func n1SmMessageFile(t *testing.T, payload []byte) *os.File {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "n1sm")
+	if err != nil {
+		t.Fatalf("could not create N1 SM message file: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	if _, err = file.Write(payload); err != nil {
+		t.Fatalf("could not write N1 SM message file: %v", err)
+	}
+	if _, err = file.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("could not rewind N1 SM message file: %v", err)
+	}
+	return file
+}
+
+// decodeGsmPti reads the 5GSM message the SMF built and returns its message type and PTI, so the
+// assertions read what went on the wire rather than a field the test arranged.
+//
+// The message is decoded to prove it is well formed, but the PTI is taken from the encoded octet:
+// TS 24.501 clause 9.6 puts the procedure transaction identity in the third octet of every 5GSM
+// message, which makes the read independent of the message type and of how the library populates
+// its header struct.
+func decodeGsmPti(t *testing.T, file *os.File) (msgType, pti uint8) {
+	t.Helper()
+
+	if file == nil {
+		t.Fatal("no N1 SM message was attached to the rejection")
+	}
+	// The SMF builds the rejection into a temp file of its own and nothing in a test will clean it
+	// up, so this helper does.
+	t.Cleanup(func() {
+		name := file.Name()
+		_ = file.Close()
+		_ = os.Remove(name)
+	})
+
+	payload, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("could not read the rejection's N1 SM message: %v", err)
+	}
+	if len(payload) < 4 {
+		t.Fatalf("the rejection's N1 SM message is %d bytes, too short to be a 5GSM message", len(payload))
+	}
+
+	// Decode from a copy: GsmMessageDecode takes a pointer to the slice and consumes it, and the
+	// octet is read from the payload afterwards.
+	decoded := make([]byte, len(payload))
+	copy(decoded, payload)
+	m := nas.NewMessage()
+	if err = m.GsmMessageDecode(&decoded); err != nil {
+		t.Fatalf("could not decode the rejection's N1 SM message: %v", err)
+	}
+	return m.GsmHeader.GetMessageType(), payload[2]
+}
+
+// TestEstablishmentRejectEchoesRequestPti drives the producer, not the reject builder. That
+// distinction is the whole test: GeneratePDUSessionEstablishmentReject reads smContext.Pti, so a
+// test that builds the rejection itself supplies the value the producer is supposed to have
+// recorded, and cannot fail when the producer does not record it.
+func TestEstablishmentRejectEchoesRequestPti(t *testing.T) {
+	const pduSessionID = 10
+
+	// A context that has never handled a request: Pti is the zero value, exactly as it is when an
+	// establishment is refused before HandlePDUSessionEstablishmentRequest runs.
+	smContext := smf_context.NewSMContext("imsi-208930100007488", pduSessionID)
+
+	request := models.NewPostSmContextsRequest()
+	request.SetJsonData(models.SmContextCreateData{
+		Supi:         openapi.PtrString("imsi-208930100007488"),
+		PduSessionId: openapi.PtrInt32(pduSessionID),
+		Dnn:          openapi.PtrString(unservedDnn),
+		// SNssai must be set: the refusal logs createData.SNssai.Sst before building the
+		// rejection, so a nil S-NSSAI panics before the message under test exists.
+		SNssai: &models.Snssai{Sst: 1, Sd: openapi.PtrString("010203")},
+	})
+	request.SetBinaryDataN1SmMessage(n1SmMessageFile(t, encodeEstablishmentRequest(t, pduSessionID, requestPti)))
+
+	txn := transaction.NewTransaction(*request, nil, svcmsgtypes.CreateSmContext)
+	txn.Ctxt = smContext
+
+	// The refusal is reported as an error, which is expected and not what this test is about.
+	if err := HandlePDUSessionSMContextCreate(txn); err == nil {
+		t.Fatal("expected the unserved DNN to be refused, but the establishment was accepted")
+	}
+
+	response, ok := txn.Rsp.(*httpwrapper.Response)
+	if !ok {
+		t.Fatalf("expected an httpwrapper.Response, got %T", txn.Rsp)
+	}
+	body, ok := response.Body.(*models.PostSmContexts400Response)
+	if !ok {
+		t.Fatalf("expected a PostSmContexts400Response, got %T", response.Body)
+	}
+
+	msgType, pti := decodeGsmPti(t, body.GetBinaryDataN1SmMessage())
+	if msgType != nas.MsgTypePDUSessionEstablishmentReject {
+		t.Fatalf("built message type = %#02x, want PDU SESSION ESTABLISHMENT REJECT (%#02x)",
+			msgType, nas.MsgTypePDUSessionEstablishmentReject)
+	}
+	if pti != requestPti {
+		t.Errorf("rejection carries PTI %#02x, want the request's %#02x: TS 24.501 clause 7.3.1 "+
+			"item e) requires the UE to ignore an establishment reject whose PTI is unassigned, so "+
+			"a refusal sent with PTI 0 is not delivered at all", pti, requestPti)
+	}
+}
+
+// TestReleaseRejectEchoesRequestPti covers the sibling instance: the release request that names a
+// PDU session the context does not hold takes a branch that skips
+// HandlePDUSessionReleaseRequest, and so skips the only place the PTI was recorded.
+func TestReleaseRejectEchoesRequestPti(t *testing.T) {
+	const (
+		contextPduSessionID   = 10
+		requestedPduSessionID = 99
+	)
+
+	// The context is deliberately left in its initial state rather than driven to SmStateActive.
+	// The branch under test does not depend on the state - the handler only logs when it is not
+	// active - and ChangeState reports subscriber metrics through smContext.PDUAddress.Ip whenever
+	// either state is active, which a context with no allocated address cannot satisfy.
+	smContext := smf_context.NewSMContext("imsi-208930100007488", contextPduSessionID)
+
+	request := models.UpdateSmContextRequest{}
+	request.SetJsonData(models.SmContextUpdateData{})
+	request.SetBinaryDataN1SmMessage(n1SmMessageFile(t, encodeReleaseRequest(t, requestedPduSessionID, requestPti)))
+
+	txn := transaction.NewTransaction(request, nil, svcmsgtypes.UpdateSmContext)
+	txn.Ctxt = smContext
+
+	response := models.NewUpdateSmContext200Response()
+	if err := HandleUpdateN1Msg(txn, response, &pfcpAction{}); err != nil {
+		t.Fatalf("HandleUpdateN1Msg returned %v, want the release to be refused without error", err)
+	}
+
+	msgType, pti := decodeGsmPti(t, response.GetBinaryDataN1SmMessage())
+	if msgType != nas.MsgTypePDUSessionReleaseReject {
+		t.Fatalf("built message type = %#02x, want PDU SESSION RELEASE REJECT (%#02x)",
+			msgType, nas.MsgTypePDUSessionReleaseReject)
+	}
+	// Assert equality with the request rather than merely non-zero: this context belongs to an
+	// established session, so it can carry a stale assigned PTI from an earlier procedure, which
+	// clause 7.3.1 item b) makes the UE answer with cause 47 rather than ignore.
+	if pti != requestPti {
+		t.Errorf("rejection carries PTI %#02x, want the request's %#02x", pti, requestPti)
+	}
+}
+
+// TestErrorCauseRejectsCarryContextPti is the weaker, builder-level guard. It cannot fail for the
+// defect the two tests above cover, because it supplies the PTI itself - it guards the encoder and
+// the cause table against a rejection that drops the identity on the way to the wire.
+//
+// It iterates smferrors.ErrorType rather than smferrors.ErrorCause, because ErrorCause also holds
+// InvalidPDUSessionIdentity, which belongs to the release path: GeneratePDUSessionEstablishmentReject
+// dereferences ErrorType[cause].Status, so a key present in only one of the two maps would panic
+// here rather than report anything. smf#633 pins that relationship between the maps.
+func TestErrorCauseRejectsCarryContextPti(t *testing.T) {
+	for cause := range smferrors.ErrorType {
+		t.Run(cause, func(t *testing.T) {
+			smContext := smf_context.NewSMContext("imsi-208930100007488", 10)
+			smContext.Pti = requestPti
+
+			response := smContext.GeneratePDUSessionEstablishmentReject(cause)
+			body, ok := response.Body.(*models.PostSmContexts400Response)
+			if !ok {
+				t.Fatalf("expected a PostSmContexts400Response, got %T", response.Body)
+			}
+
+			msgType, pti := decodeGsmPti(t, body.GetBinaryDataN1SmMessage())
+			if msgType != nas.MsgTypePDUSessionEstablishmentReject {
+				t.Fatalf("built message type = %#02x, want PDU SESSION ESTABLISHMENT REJECT (%#02x)",
+					msgType, nas.MsgTypePDUSessionEstablishmentReject)
+			}
+			if pti != requestPti {
+				t.Errorf("rejection for %q carries PTI %#02x, want %#02x", cause, pti, requestPti)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is wrong

A refused PDU session establishment now reaches the UE — and a conformant UE is required to throw
it away.

TS 24.501 clause 7.3.1, UE procedures item e): *"In case the UE receives a PDU SESSION
ESTABLISHMENT ACCEPT message, a PDU SESSION ESTABLISHMENT REJECT message, a PDU SESSION
MODIFICATION REJECT message or a PDU SESSION RELEASE REJECT message in which the PTI value is an
unassigned value, the UE shall ignore the message."* The SMF sends those rejects with PTI 0, which
is unassigned, so the UE ignores the refusal, keeps retransmitting until T3580 is exhausted, and
reports that the network never answered. The refusal is delivered and is indistinguishable from
silence.

Measured on a cluster with UERANSIM, which logs the decode UE-side:

```
Initial Registration is successful
PDU Session Establishment Reject received [MISSING_OR_UNKNOWN_DNN_IN_A_SLICE]   <- 249 ms, cause 70
Received PTI [0] value is invalid
Sending SM Cause[INVALID_PTI_VALUE] for PSI[1]
Retransmitting PDU Session Establishment Request due to T3580 expiry
... five attempts ...
PDU Session Establishment procedure failure, no response from the network after 5 attempts
```

## Why

`smContext.Pti` is assigned in exactly one place on this path — `HandlePDUSessionEstablishmentRequest`
(`context/gsm_handler.go`) — and `HandlePDUSessionSMContextCreate` does not call it until after six
refusals can already have been raised: an unserved DNN, two UDM discovery failures, IP allocation,
and two subscription-data failures. Those six build their rejection from a context whose PTI is
still zero. The other ten of the sixteen `GeneratePDUSessionEstablishmentReject` call sites are
fine.

The NAS message is decoded twenty-four lines before the first refusal, so the identity is already
in hand and merely unstored. Storing it there covers all sixteen sites, and leaves no window in
which a refusal added later could precede it.

The same shape appears once more, on the release path: a release request naming a PDU session the
context does not hold is answered with a release reject built on the branch that never reaches
`HandlePDUSessionReleaseRequest`.

## Verified on a cluster, before and after

Same rig, same UE, same unserved DNN, with the fix deployed:

| | before | after |
|---|---|---|
| reject received, cause | yes, cause 70 | yes, cause 70 |
| `Received PTI [0] value is invalid` | every reject | 0 |
| `Retransmitting … due to T3580 expiry` | 4, then abandonment | 0 |
| `no response from the network after 5 attempts` | yes | 0 |
| procedure outcome | never completed | completes on each reject |

After the fix the UE re-asks about once a second, and that is the fix working rather than a new
problem: each of those is a **fresh** procedure with its own establishment request, not a
retransmission of an unanswered one. The UE completes every procedure and then starts another
because its configuration wants a session on that DNN and the simulator implements no back-off for
any reject cause. Before the fix it could not complete a single one.

## Which half is measured

- **The establishment instance is measured end to end**, both before and after, as above.
- **The release instance was found by inspection**, then reproduced by a unit test that fails
  before its fix and passes after. It is **not** measured on a cluster. Its symptom may also
  differ: that context belongs to an established session, so it can carry a stale assigned PTI
  rather than zero, which clause 7.3.1 UE item b) answers with 5GSM STATUS cause 47 rather than by
  ignoring.

## Tests

The tests drive the producer, not the reject builders, and that distinction is the whole point.
`GeneratePDUSessionEstablishmentReject` reads `smContext.Pti`, so a table-driven test that builds
the rejection itself supplies the value the producer is supposed to have recorded and **cannot
fail** for this defect. The two new tests construct a request the producer has to decode and read
the PTI back out of the encoded rejection, from the third octet, where clause 9.6 puts it.

Each was confirmed to fail before its own fix and pass after, independently: removing only the
establishment assignment fails only the establishment test, and likewise for the release one. The
table-driven test over the cause table is included as a weaker guard on the encoder and the cause
table, and is documented in the file as passing either way.

The establishment test needs no stub of any kind: the unserved-DNN refusal is the first branch and
returns before any UDM, PCF or UPF call.

## Deliberately not in this PR

- **`SetPTI` in `context/gsm_build.go`** — already correct. The bug is not that the builder cannot
  see the identity.
- **The cause values.** Verified unchanged: cause 70 on the DNN path, cause 31 on a PCF failure.
- **The order in which refusals are detected.** A DNN that is not served should be refused without
  parsing the UE's container; reordering to fix a field assignment would also make those refusals
  depend on that parse succeeding.
- **The duplicate assignment in `HandlePDUSessionEstablishmentRequest`.** Left in place so that
  handler stays correct on its own rather than depending on its caller having stored the identity.
- **The PDU session identity in the reject** and clause 7.3.2's handling of it. Only the PTI was
  observed wrong.
- **The modification reject.** `BuildGSMPDUSessionModificationReject` is commented out and no live
  path sends one, so there is nothing to fix here.
- **`BuildGSMPDUSessionReleaseCommand` on its two network-side callers.** This is the inverse
  question and it is pre-existing: clause 6.3.3.2 requires a network-requested release command to
  carry an unassigned PTI, those callers read the context's, and the code does not record whether
  a release was UE-requested. Distinguishing that is a behavioural change rather than the echoing
  of an identity already in hand, so it is out of scope. This PR does not make it worse — those
  paths run after establishment, where the PTI was already assigned before this change.

## Gates

`go test -race ./... -count=1` clean; `golangci-lint` v2.13.2 (the version this repo's CI pins)
clean; REUSE compliant.
