### PR TITLE
Discard a modification response whose session is gone, instead of dereferencing nil

### DIFF
--- a/pfcp/handler/handler.go
+++ b/pfcp/handler/handler.go
@@ -587,6 +587,10 @@ func HandlePfcpSessionModificationResponse(msg *udp.Message) {
 		}
 	}
 	smContext := smf_context.GetSMContextBySEID(SEID)
+	if smContext == nil {
+		logger.PfcpLog.Warnf("PFCP Session Modification Response found SM context nil for SEID[%d], response discarded", SEID)
+		return
+	}
 
 	logger.PfcpLog.Infoln("in HandlePfcpSessionModificationResponse")
 

--- a/pfcp/handler/handler_test.go
+++ b/pfcp/handler/handler_test.go
@@ -394,3 +394,57 @@ func TestHandlePfcpSessionEstablishmentResponseChannelGatedByState(t *testing.T)
 		})
 	}
 }
+
+// TestHandlePfcpSessionModificationResponseNoSMContext covers a Session
+// Modification Response that arrives after its session has been released, so
+// GetSMContextBySEID returns nil. Both the accepted and the rejected branch
+// dereference smContext unconditionally, and Dispatch runs each message on its
+// own goroutine with no recover, so an unguarded dereference here ends the
+// process rather than the request. The establishment and deletion handlers
+// already check; this one must too.
+func TestHandlePfcpSessionModificationResponseNoSMContext(t *testing.T) {
+	if factory.SmfConfig.Configuration == nil {
+		factory.SmfConfig = factory.Config{
+			Configuration: &factory.Configuration{
+				KafkaInfo:        factory.KafkaInfo{EnableKafka: boolPointer(false)},
+				EnableUpfAdapter: false,
+			},
+		}
+	}
+
+	// A SEID no session was ever registered under, so the lookup returns nil.
+	const unknownSEID uint64 = 0xDEADBEEF
+
+	cases := []struct {
+		name  string
+		cause uint8
+	}{
+		{"accepted", ie.CauseRequestAccepted},
+		{"rejected", ie.CauseRequestRejected},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rsp := message.NewSessionModificationResponse(
+				0, 0, unknownSEID, 1, 0,
+				ie.NewCause(tc.cause),
+			)
+
+			udpMessage := udp.Message{
+				RemoteAddr: &net.UDPAddr{
+					IP:   net.ParseIP("3.3.3.3"),
+					Port: 8805,
+				},
+				PfcpMessage: rsp,
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("handler panicked on a response for a released session: %v", r)
+				}
+			}()
+
+			handler.HandlePfcpSessionModificationResponse(&udpMessage)
+		})
+	}
+}


### PR DESCRIPTION
## The defect

`HandlePfcpSessionModificationResponse` does not check the result of
`GetSMContextBySEID` (`pfcp/handler/handler.go:589`). That lookup returns nil once
the SEID has been removed, so a Session Modification Response that arrives after
its session was released reaches an unconditional dereference:

- `smContext.BPManager` at 593, when ULCL is enabled
- `smContext.SubPduSessLog` at 614, on the accepted branch
- `smContext.SubPfcpLog` at 637, on the rejected branch

`Dispatch` (`pfcp/dispatcher.go:17`) has no `recover` and runs each message on its
own goroutine (`pfcp/udp/udp.go:109`), so this is not a failed request — the nil
dereference ends the SMF process, and every other session it is holding goes with
it. No ULCL or adapter configuration is needed to reach it.

## The fix

The same guard the two sibling handlers in this file already have. The
establishment handler rejects a nil context before taking `SMLock` (432-435); the
deletion handler discards the response with a warning (668-672). This adds it to
the one response handler that was missing it, using the deletion handler's
wording and severity — a late response is a discard, not a fault — with the SEID
included so the log says which session. The adapter dispatcher's copy of this
handler already carries the identical check (`pfcp/adapter/adapter.go:383-386`),
so the native one was the only copy without it.

Discarding leaves no waiter behind: the SEID entry is removed only after the
context has left `SmStatePfcpModify` — `context/sm_context.go:433-437` changes
state before deleting the entry — and both signals on `SBIPFCPCommunicationChan`
are gated on that state (615, 638), so a response that finds no context would not
have been signalled even with a live pointer.

The discard path does not consume the request's PFCP transaction entry, matching
every other path through this handler: `SendPfcpSessionModificationRequest` calls
`InsertPfcpTxn` but no modification-response path has ever called `FetchPfcpTxn`.
That is pre-existing and left alone here — mentioning it only because the
establishment handler's nil-Tunnel arm does consume one, so the difference is
deliberate rather than an oversight.

## Scope

I checked every `GetSMContextBySEID` call site rather than the neighbouring
handlers alone. Ten sites across `pfcp/handler`, `pfcp/adapter` and
`pfcp/message`; this was the only unguarded one, so the change is deliberately
one handler wide.

Two of those ten look unguarded to a grep that only reads the next line or two
and are not, in case a reviewer checks the same way: the report handler's guard
sits at 721, six lines below its lookup at 715, and `handleSendPfcpSessRelReqError`
uses the inverted `if smContext != nil` form.

## Deliberately not in this change

This handler has other problems and they are separate pull requests, not
oversights:

- It holds no lock while mutating shared session state — `delete(smContext.PendingUPF, upfIP)`
  at 618 is a plain-map write against a map the producers write under `SMLock`, and
  `GetNodeIDByLocalSEID` ranges `PFCPContext` at 597, 616 and 628.
- Those cannot simply be wrapped in `SMLock`. The handler is the sole signaller of
  `SBIPFCPCommunicationChan` (622, 639) and the SBI update path waits on that channel
  while holding `SMLock` (`producer/pdu_session.go:427-428`, `:500`,
  `producer/sm_pfcp_handling.go:24`), so any acquisition before the signal deadlocks.
  That needs a decision about the wait, not a lock.
- `HandlePfcpSessionDeletionResponse` shares the unguarded `PendingUPF` write at 689.

Keeping them apart because this one is a live process abort with a four-line fix and
a test, and the others are a design question.

## Testing

`TestHandlePfcpSessionModificationResponseNoSMContext` drives the handler with a SEID
no session was registered under, as two sub-tests — the accepted and rejected branches
dereference at different lines, and a single-branch test would cover half the defect.

With the guard removed both sub-tests report
`runtime error: invalid memory address or nil pointer dereference`; with it in place
both pass. So the test fails for the defect rather than passing alongside it.

`go build ./...`, `go vet ./...` and `go test -race ./...` clean, and
`golangci-lint` reports 0 issues both in `golangci/golangci-lint:v2.13.2`, the image
`.github/workflows/main.yml:52` selects, and at the `latest` the Makefile defaults to.
